### PR TITLE
Nette 2.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
 	"homepage": "https://github.com/peckadesign/pdForms",
 	"authors": [
 		"PeckaDesign, s.r.o <support@peckadesign.cz>",
-		"Radek Šerý <radek.sery@peckadesign.cz>",
-		"Vít Kutný <vit.kutny@peckadesign.cz>"
+		"Radek Šerý <radek.sery@peckadesign.cz>"
 	],
 	"main": "pdForms.js",
 	"license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
 	"license": "MIT",
 	"dependencies": {
 		"jquery": ">=1.7",
-		"nette-forms": "~2.3"
+		"nette-forms": "~2.4"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
 	"require": {
 		"php": "7.1.*",
 		"ext-json": "*",
-		"nette/application": "2.3.*",
-		"nette/forms": "2.3.*",
-		"nette/di": "2.3.*",
+		"nette/application": "2.3.* || 2.4.*",
+		"nette/forms": "2.3.* || 2.4.*",
+		"nette/di": "2.3.* || 2.4.*",
 		"nette/utils": "2.*",
 		"pd/utils": "1.*"
 	},

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
 	"require": {
 		"php": "7.1.*",
 		"ext-json": "*",
-		"nette/application": "2.3.* || 2.4.*",
-		"nette/forms": "2.3.* || 2.4.*",
-		"nette/di": "2.3.* || 2.4.*",
+		"nette/application": "2.4.*",
+		"nette/forms": "2.4.*",
+		"nette/di": "2.4.*",
 		"nette/utils": "2.*",
 		"pd/utils": "1.*"
 	},

--- a/doc/live_validation.md
+++ b/doc/live_validation.md
@@ -14,6 +14,8 @@ var input = document.getElementById('muj_input');
 input.dispatchEvent(new Event('validate'));
 ```
 
+Pro podporu v IE9+ je potřeba přidat ještě soubor `<script src="pdForms.polyfills.js"></script>`
+
 ### Vlastní událost pro spuštění validace 
 Pokud chcete validovat formulářové pole při libovolné jiné události (`keyup`, `focusout`, vlastní událost, ...), stačí na formulářový prvek přidat data atribut `data-pdforms-validate-on` obsahující název události. Validační callback se poté naváže i na tuto událost. 
 ```html

--- a/doc/live_validation.md
+++ b/doc/live_validation.md
@@ -10,13 +10,13 @@ Pro použití na webu stačí nalinkovat `netteForms.js`, jednotlivé validátor
 <script src="pdForms.js"></script>
 ```
 
-V tomto základním nastavení se budou formulářové prvky validovat při JS události `change`. Validaci na prvku je možné také vyvolat pomocí vlastní události `validate`, viz příklad:
+V tomto základním nastavení se budou formulářové prvky validovat při JS událostech `change` nebo `focusout` (záleží na typu prvku). Validaci na prvku je možné také vyvolat pomocí vlastní události `validate`, viz příklad:
 ```javascript
 var input = document.getElementById('muj_input');
 input.dispatchEvent(new Event('validate'));
 ```
 
-Pro podporu v IE9+ je potřeba přidat ještě soubor `<script src="pdForms.polyfills.js"></script>`
+Pro podporu v IE9+ je potřeba přidat ještě soubor `<script src="pdForms.polyfills.js"></script>`.
 
 ### Vlastní událost pro spuštění validace 
 Pokud chcete validovat formulářové pole při libovolné jiné události (`keyup`, `focusout`, vlastní událost, ...), stačí na formulářový prvek přidat data atribut `data-pdforms-validate-on` obsahující název události. Validační callback se poté naváže i na tuto událost. 

--- a/doc/live_validation.md
+++ b/doc/live_validation.md
@@ -1,10 +1,12 @@
 ## Live validace
 
-Pro použití na webu stačí nalinkovat `netteForms.js` a `pdForms.js` a vypnout automatickou inicializaci nette forms.
+Pro použití na webu stačí nalinkovat `netteForms.js`, jednotlivé validátory a `pdForms.js` a vypnout automatickou inicializaci nette forms.
 
 ```html
 <script>var Nette = { noInit: true };</script>
 <script src="netteForms.js"></script>
+<script src="validators/pdForms.validator.phone.js"></script>
+<script src="validators/..."></script>
 <script src="pdForms.js"></script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",
-		"Petr Klobás <petr.klobas@peckadesign.cz>",
-		"Vít Kutný <vit.kutny@peckadesign.cz>"
+		"Petr Klobás <petr.klobas@peckadesign.cz>"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	"license": "MIT",
 	"homepage": "https://github.com/peckadesign/pdForms",
 	"dependencies": {
-		"jquery": ">=1.7"
+		"jquery": ">=1.7",
+		"nette-forms": "~2.4.0"
 	},
 	"devDependencies": {}
 }

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,14 +1,12 @@
 /**
  * @name pdForms
- *
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @author Vít Kutný <vit.kutny@peckadesign.cz>
- *
  * @version 2.0.0
  *
- * - adds custom validation rules for optional rule (non-blocking errors, form can be still submitted)
- * - changes some netteForms methods
- * - add support for "asynchronous" validation rules - validation depends on AJAX response; limitations:
+ * Features:
+ * - live validation
+ * - support for optional rules (non-blocking errors, form can be still submitted)
+ * - support for "asynchronous" validation rules - validation depends on AJAX response; there are some limitations:
  *   - ajax rule cannot be used as condition! (might be possible by using similar technique as with mandatory ajax rules)
  *   - mandatory ajax rule won't block form submit (in JS), so the page reloads (form won't be submitted because of
  *     server side check), check the todo list
@@ -24,283 +22,317 @@
  *      - when all mandatory ajax rules are processed (prior step is done), check if ajaxErrors is empty - if so
  *        return true, otherwise return false
  */
-
-var pdForms = pdForms || {};
-
-
-/**
- * Version
- */
-pdForms.version = '2.0.0';
-
-
-/**
- * Nette methods which are later overridden
- */
-pdForms.Nette = {
-	validateControl: Nette.validateControl,
-	toggleControl:   Nette.toggleControl,
-	initForm:        Nette.initForm
-};
-
-
-/**
- * Constants for messages. Used in CSS class names.
- */
-pdForms.constants = {
-	ERROR_MESSAGE: 'error',
-	INFO_MESSAGE: 'info',
-	OK_MESSAGE: 'valid',
-
-	// returns searialized class names, each one prefixed with "pdforms-" string
-	toString: function() {
-		var s = '';
-
-		for (var i in this) {
-			s += (typeof this[i] !== 'function') ? ' pdforms-' + String(this[i]) : '';
-		}
-
-		return s.slice(1);
-	}
-};
-
-
-pdForms.isOptionalRule = function(rule) {
-	return typeof rule.arg === 'object' && rule.arg.optional;
-};
-
-
-pdForms.isAjaxRule = function(rule) {
-	return typeof rule.arg === 'object' && 'ajaxUrl' in rule.arg;
-};
-
-
-/**
- * Method converts rules from Pd format into Nette compatible format. There are two fags set - isOptional and isAjax -
- * and rule.msg is converted into an object.
- */
-pdForms.normalizeRules = function(rules) {
-	for (var j in rules) {
-		var rule = rules[j];
-		rule.isOptional = pdForms.isOptionalRule(rule);
-		rule.isAjax = pdForms.isAjaxRule(rule);
-
-		if (typeof rule.msg === 'undefined') {
-			rule.msg = {};
-		} else if (typeof rule.msg === 'string') {
-			rule.msg = { 'invalid': rule.msg };
-		}
-
-		if (typeof rule.arg === 'object' && 'msg' in rule.arg) {
-			for (var i in rule.arg.msg) {
-				rule.msg[i] = rule.arg.msg[i];
-			}
-		}
-
-		if (rule.rules) {
-			rule.rules = pdForms.normalizeRules(rule.rules);
-		}
+(function(global, factory) {
+	if (!global.JSON) {
+		return;
 	}
 
-	return rules;
-};
-
-
-/**
- * Returns first rule with name op from rules or null.
- */
-pdForms.getRuleByOp = function(rules, op) {
-	for (var j in rules) {
-		var rule = rules[j];
-
-		if (pdForms.formatOperation(rule.op) === op) {
-			return rule;
-		} else if (rule.rules) {
-			return pdForms.getRuleByOp(rule.rules, op);
-		}
-	}
-
-	return null;
-};
-
-
-/**
- * Validates ever-focused inputs, using data-nette-rules and data-pd-rules. Validates all grouped elements together.
- * This function is not used when validating whole form, eg. by submit event.
- */
-pdForms.validateInput = function(e, $inputs) {
-	var $validate = $(this);
-
-	if (groupName = $(this).data('validation-group')) {
-		$validate = $inputs.filter(function() {
-			return $(this).data('validation-group') === groupName;
+	if (typeof define === 'function' && define.amd) {
+		define(function() {
+			return factory(global);
 		});
+	} else if (typeof module === 'object' && typeof module.exports === 'object') {
+		module.exports = factory(global);
+	} else {
+		global.pdForms = factory(global);
+
+		if (global.Nette) {
+			global.Nette.initOnLoad();
+		}
 	}
 
-	$validate.each(function() {
-		if ($(this).data('ever-focused')) {
-			// validate control using nette-rules && pd-rules (which are inside nette-rules actually)
-			var ret = Nette.validateControl(this);
+}(typeof window !== 'undefined' ? window : this, function(window) {
 
-			var rules = Nette.parseJSON(this.getAttribute('data-nette-rules'));
-			rules = pdForms.normalizeRules(rules);
-			var hasAjaxRule = pdForms.hasAjaxRule(rules);
+	var pdForms = window.pdForms || {};
 
-			// has to be here and not inside validateControl as it should add ok class only if whole input is valid (not only parts of condional rule etc.)
-			if (ret && ! hasAjaxRule) {
-				// add pdforms-valid class name if the input is valid
-				pdForms.addMessage(this, null, pdForms.constants.OK_MESSAGE);
-			}
-		}
-	});
-};
+	pdForms.version = '2.0.0';
 
 
-/**
- * Validates form element using optional nette-rules.
- */
-pdForms.validateControl = function(elem, rules, onlyCheck) {
-	// assumes the input is valid, therefore removing all messages except those associated with ajax rules; this
-	// prevents flashing of message, when ajax rule is evaluated - ajax rules removes their messages when the ajax
-	// rule is evaluated; when onlyCheck is true, we dont' want to modify DOM at all
-	if (! onlyCheck) {
-		pdForms.removeMessages(elem, false);
+	if (! Element.prototype.matches) {
+		Element.prototype.matches =
+			Element.prototype.msMatchesSelector ||
+			Element.prototype.webkitMatchesSelector;
 	}
 
-	// validate rules one-by-one to know which passed
-	for (var id = 0, len = rules.length; id < len; id++) {
-		var rule = rules[id];
-		var op = pdForms.formatOperation(rule.op);
+	/**
+	 * Nette methods which are later overridden
+	 */
+	pdForms.Nette = {
+		validateControl: Nette.validateControl,
+		toggleControl:   Nette.toggleControl,
+		initForm:        Nette.initForm
+	};
 
-		// if ajax validator is used, validate & push into queue of not-yet resolved rules
-		if (rule.isAjax) {
-			var key = pdForms.getAjaxQueueKey(elem, op);
-			pdForms.ajaxQueue[key] = {
-				msg: rule.msg,
-				isOptional: rule.isOptional,
-				onlyCheck: onlyCheck
-			};
-		}
 
-		var condition = !!rule.rules;
-		var valid = pdForms.Nette.validateControl(elem, [rule], ! condition || onlyCheck);
+	/**
+	 * Constants for messages. Used in CSS class names.
+	 */
+	pdForms.constants = {
+		ERROR_MESSAGE: 'error',
+		INFO_MESSAGE: 'info',
+		OK_MESSAGE: 'valid',
 
-		// if rule is ajax, then do not write any message
-		if (! rule.isAjax) {
-			if (! onlyCheck) {
-				if (! valid) {
-					// if the rule is sync and we have a new message, we need to remove previous messages
-					// (including ajax rules associated); checking for message presence ensures that conditional rules
-					// will show their message - their evaluating goes from deepest rule (where the message is defined),
-					// therefore condition is evaluated at last and must not remove the message
-					if (rule.msg.invalid) {
-						pdForms.removeMessages(elem, true);
-					}
-					pdForms.addMessage(elem, rule.msg.invalid, rule.isOptional ? pdForms.constants.INFO_MESSAGE : pdForms.constants.ERROR_MESSAGE);
-				}
-				else if (rule.msg.valid) {
-					pdForms.addMessage(elem, rule.msg.valid, pdForms.constants.OK_MESSAGE);
-				}
+		// returns searialized class names, each one prefixed with "pdforms-" string
+		toString: function() {
+			var s = '';
+
+			for (var i in this) {
+				s += (typeof this[i] !== 'function') ? ' pdforms-' + String(this[i]) : '';
 			}
 
-			if (! valid && ! rule.isOptional) {
-				return valid;
-			}
-		}
-	}
-
-	return true;
-};
-
-
-pdForms.formatOperation = function(op) {
-	if (op.charAt(0) === ':') {
-		op = op.substr(1);
-	}
-	op = op.replace('::', '_');
-	op = op.replace(/\\/g, '');
-
-	return op;
-};
-
-
-/**
- * Checks if given rules contains any ajax rule
- */
-pdForms.hasAjaxRule = function(rules) {
-	for (var id = 0, len = rules.length; id < len; id++) {
-		if (rules[id].isAjax || (rules[id].rules && pdForms.hasAjaxRule(rules[id].rules))) {
-			return true;
-		}
-	}
-
-	return false;
-};
-
-
-
-/**
- * Queue of ajax validation rules which has not been yet processed.
- */
-pdForms.ajaxQueue = {};
-
-
-/**
- * Get key to ajax queue for given element and operation
- */
-pdForms.getAjaxQueueKey = function(elem, op) {
-	return elem.getAttribute('id') + '--' + op;
-};
-
-
-/**
- * Returns default settings for AJAX rules based on parameters. Either to be used directly as param for $.nette.ajax
- * call or as a default settings to be extended by custom properties.
- */
-pdForms.getAjaxRequestSettings = function(elem, op, arg, data) {
-	return {
-		url: arg.ajaxUrl,
-		data: (data ? data : null),
-		timeout: 5000,
-		spinner: '.pdforms-ajax-spinner--' + elem.id,
-		off: ['snippets', 'history', 'unique', 'abort'],
-		beforeSend: function(jqXHR, settings) {
-			$(elem).addClass('inp-loading');
-		},
-		success: function(payload) {
-			var status = payload.status || (payload.valid ? 'valid' : 'invalid');
-
-			pdForms.ajaxEvaluate(elem, op, status, payload, arg);
-		},
-		error: function(jqXHR, status, error, settings) {
-			pdForms.ajaxEvaluate(elem, op, error, undefined, arg);
-		},
-		complete: function(jqXHR, status, settings) {
-			$(elem).removeClass('inp-loading');
+			return s.slice(1);
 		}
 	};
-};
 
 
+	pdForms.isOptionalRule = function(rule) {
+		return typeof rule.arg === 'object' && rule.arg.optional;
+	};
 
-/**
- * For given element and operation write validation result message and remove from queue; called by AJAX validator
- * after response is received.
- */
-pdForms.ajaxEvaluate = function(elem, op, status, payload, arg) {
-	var key = pdForms.getAjaxQueueKey(elem, op);
 
-	// found request in queue, otherwise do nothing
-	if (key in pdForms.ajaxQueue) {
-		var msg = pdForms.ajaxQueue[key].msg;
-		var isOptional = pdForms.ajaxQueue[key].isOptional;
-		var onlyCheck = pdForms.ajaxQueue[key].onlyCheck;
-		delete pdForms.ajaxQueue[key];
+	pdForms.isAjaxRule = function(rule) {
+		return typeof rule.arg === 'object' && 'ajaxUrl' in rule.arg;
+	};
 
-		// write validation result message
+
+	/**
+	 * Method converts rules from Pd format into Nette compatible format. There are two fags set - isOptional and isAjax -
+	 * and rule.msg is converted into an object.
+	 */
+	pdForms.normalizeRules = function(rules) {
+		for (var j in rules) {
+			var rule = rules[j];
+			rule.isOptional = pdForms.isOptionalRule(rule);
+			rule.isAjax = pdForms.isAjaxRule(rule);
+
+			if (typeof rule.msg === 'undefined') {
+				rule.msg = {};
+			} else if (typeof rule.msg === 'string') {
+				rule.msg = { 'invalid': rule.msg };
+			}
+
+			if (typeof rule.arg === 'object' && 'msg' in rule.arg) {
+				for (var i in rule.arg.msg) {
+					rule.msg[i] = rule.arg.msg[i];
+				}
+			}
+
+			rule.msg.replace = function(reg, callback) {
+				for (var i in this) {
+					if (typeof this[i] === 'string') {
+						this[i] = this[i].replace(reg, callback);
+					}
+				}
+
+				return this;
+			};
+
+			if (rule.rules) {
+				rule.rules = pdForms.normalizeRules(rule.rules);
+			}
+		}
+
+		return rules;
+	};
+
+
+	/**
+	 * Returns first rule with name op from rules or null.
+	 */
+	pdForms.getRuleByOp = function(rules, op) {
+		for (var j in rules) {
+			var rule = rules[j];
+
+			if (pdForms.formatOperation(rule.op) === op) {
+				return rule;
+			} else if (rule.rules) {
+				return pdForms.getRuleByOp(rule.rules, op);
+			}
+		}
+
+		return null;
+	};
+
+
+	/**
+	 * Validates ever-focused inputs, using data-nette-rules and data-pd-rules. Validates all grouped elements together.
+	 * This function is not used when validating whole form, eg. by submit event.
+	 */
+	pdForms.liveValidation = function(e) {
+		var validate = [e.target];
+		var groupName = e.target.getAttribute('data-validation-group');
+
+		if (groupName) {
+			var elems = e.target.form.elements;
+			for (var i = 0; i < elems.length; i++) {
+				if (elems[i] !== e.target && elems[i].getAttribute('data-validation-group') === groupName) {
+					validate.push(elems[i]);
+				}
+			}
+		}
+
+		validate.forEach(function(elem) {
+			if (elem.getAttribute('data-pdforms-ever-focused')) {
+				// validate control using nette-rules && pd-rules (which are inside nette-rules actually)
+				var ret = Nette.validateControl(elem);
+				var rules = Nette.parseJSON(elem.getAttribute('data-nette-rules'));
+				rules = pdForms.normalizeRules(rules);
+				var hasAjaxRule = pdForms.hasAjaxRule(rules);
+
+				// has to be here and not inside validateControl as it should add ok class only if whole input is valid (not only parts of condional rule etc.)
+				if (ret && ! hasAjaxRule) {
+					// add pdforms-valid class name if the input is valid
+					pdForms.addMessage(elem, null, pdForms.constants.OK_MESSAGE);
+				}
+			}
+		});
+	};
+
+
+	/**
+	 * Validates form element using optional nette-rules.
+	 */
+	pdForms.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
+		// assumes the input is valid, therefore removing all messages except those associated with ajax rules; this
+		// prevents flashing of message, when ajax rule is evaluated - ajax rules removes their messages when the ajax
+		// rule is evaluated; when onlyCheck is true, we dont' want to modify DOM at all
 		if (! onlyCheck) {
-			// remove old messages, only when onlyCheck is false
-			pdForms.removeMessages(elem, true);
+			pdForms.removeMessages(elem, false);
+		}
+
+		// validate rules one-by-one to know which passed
+		for (var id = 0, len = rules.length; id < len; id++) {
+			var rule = rules[id];
+			var op = pdForms.formatOperation(rule.op);
+
+			// if ajax validator is used, validate & push into queue of not-yet resolved rules
+			if (rule.isAjax) {
+				var key = pdForms.getAjaxQueueKey(elem, op);
+				pdForms.ajaxQueue[key] = {
+					msg: rule.msg,
+					isOptional: rule.isOptional,
+					onlyCheck: onlyCheck
+				};
+			}
+
+			var valid = pdForms.Nette.validateControl(elem, [rule], onlyCheck, value, emptyOptional);
+
+			// if rule is ajax, then do not write any message
+			if (! rule.isAjax) {
+				if (! onlyCheck) {
+					if (! valid) {
+						// if the rule is sync and we have a new message, we need to remove previous messages
+						// (including ajax rules associated); checking for message presence ensures that conditional rules
+						// will show their message - their evaluating goes from deepest rule (where the message is defined),
+						// therefore condition is evaluated at last and must not remove the message
+						if (rule.msg.invalid) {
+							pdForms.removeMessages(elem, true);
+						}
+						pdForms.addMessage(elem, rule.msg.invalid, rule.isOptional ? pdForms.constants.INFO_MESSAGE : pdForms.constants.ERROR_MESSAGE);
+					}
+					else if (rule.msg.valid) {
+						pdForms.addMessage(elem, rule.msg.valid, pdForms.constants.OK_MESSAGE);
+					}
+				}
+
+				if (! valid && ! rule.isOptional) {
+					return valid;
+				}
+			}
+		}
+
+		return true;
+	};
+
+
+	pdForms.formatOperation = function(op) {
+		if (op.charAt(0) === ':') {
+			op = op.substr(1);
+		}
+		op = op.replace('::', '_');
+		op = op.replace(/\\/g, '');
+
+		return op;
+	};
+
+
+	/**
+	 * Checks if given rules contains any ajax rule
+	 */
+	pdForms.hasAjaxRule = function(rules) {
+		for (var id = 0, len = rules.length; id < len; id++) {
+			if (rules[id].isAjax || (rules[id].rules && pdForms.hasAjaxRule(rules[id].rules))) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+
+
+	/**
+	 * Queue of ajax validation rules which has not been yet processed.
+	 */
+	pdForms.ajaxQueue = {};
+
+
+	/**
+	 * Get key to ajax queue for given element and operation
+	 */
+	pdForms.getAjaxQueueKey = function(elem, op) {
+		return elem.getAttribute('id') + '--' + op;
+	};
+
+
+	/**
+	 * Returns default settings for AJAX rules based on parameters. Either to be used directly as param for $.nette.ajax
+	 * call or as a default settings to be extended by custom properties.
+	 */
+	pdForms.getAjaxRequestSettings = function(elem, op, arg, data) {
+		return {
+			url: arg.ajaxUrl,
+			data: (data ? data : null),
+			timeout: 5000,
+			spinner: '.pdforms-ajax-spinner--' + elem.id,
+			off: ['snippets', 'history', 'unique', 'abort'],
+			beforeSend: function(jqXHR, settings) {
+				$(elem).addClass('inp-loading');
+			},
+			success: function(payload) {
+				var status = payload.status || (payload.valid ? 'valid' : 'invalid');
+
+				pdForms.ajaxEvaluate(elem, op, status, payload, arg);
+			},
+			error: function(jqXHR, status, error, settings) {
+				pdForms.ajaxEvaluate(elem, op, error, undefined, arg);
+			},
+			complete: function(jqXHR, status, settings) {
+				$(elem).removeClass('inp-loading');
+			}
+		};
+	};
+
+
+
+	/**
+	 * For given element and operation write validation result message and remove from queue; called by AJAX validator
+	 * after response is received.
+	 */
+	pdForms.ajaxEvaluate = function(elem, op, status, payload, arg) {
+		var key = pdForms.getAjaxQueueKey(elem, op);
+
+		// found request in queue, otherwise do nothing
+		if (key in pdForms.ajaxQueue) {
+			var msg = pdForms.ajaxQueue[key].msg;
+			var isOptional = pdForms.ajaxQueue[key].isOptional;
+			var onlyCheck = pdForms.ajaxQueue[key].onlyCheck;
+			delete pdForms.ajaxQueue[key];
+
+			// write validation result message
+			if (! onlyCheck) {
+				// remove old messages, only when onlyCheck is false
+				pdForms.removeMessages(elem, true);
 
 			if (status in msg && msg[status]) {
 				var msgType = pdForms.constants.ERROR_MESSAGE;
@@ -325,328 +357,355 @@ pdForms.ajaxEvaluate = function(elem, op, status, payload, arg) {
 			}
 		}
 
+			// fill in input fields recieved in payload
+			pdForms.ajaxFillDependentInputs(elem, payload, arg);
 
-		// fill in input fields recieved in payload
-		pdForms.ajaxFillDependentInputs(elem, payload, arg);
-
-
-		// process callback if any
-		if (typeof pdForms.ajaxCallbacks[op] === 'function') {
-			pdForms.ajaxCallbacks[op](elem, payload, arg);
-		}
-	}
-};
-
-pdForms.ajaxCallbacks = pdForms.ajaxCallbacks || {};
-
-/**
- * Fill in values into inputs defined in arg.inputs if the value is defined in payload.
- */
-pdForms.ajaxFillDependentInputs = function(elem, payload, arg) {
-	if (typeof payload === 'object' && payload.valid && typeof payload.dependentInputs === 'object' && typeof arg === 'object' && typeof arg.dependentInputs === 'object') {
-		for (var inputName in arg.dependentInputs) {
-			if (! arg.dependentInputs.hasOwnProperty(inputName)) {
-				continue;
-			}
-
-			var inputId = arg.dependentInputs[inputName];
-
-			if (! payload.dependentInputs.hasOwnProperty(inputId)) {
-				continue;
-			}
-
-			var input = document.getElementById(inputId);
-
-			if (input && ! input.value) {
-				$(input)
-					.val(payload.dependentInputs[inputId])
-					.trigger('change')
-					.trigger('validate.pdForms');
+			// process callback if any
+			if (typeof pdForms.ajaxCallbacks[op] === 'function') {
+				pdForms.ajaxCallbacks[op](elem, payload, arg);
 			}
 		}
-	}
-};
-
-
-/**
- * Display message. Either input associated or (if appropriate selector not found) as "global" form message.
- * Message placeholding:
- * 	1. First we try to find elements parent .pdforms-messages--input
- * 	2. If there is not any, then try to find closest p
- * 	3. If still no success, try to find .pdforms-messages--global
- *
- * If two or more inputs with validation rules are in same message placeholder (eg. <p> or .pdforms-messages--input), the
- * validation won't work as expected - class .error will be determined by last validated input in the placeholder and
- * messages may disappear unexpectedly :) In that case, you might be better with using .pdforms-messages--global or splitting
- * the <p> (.pdforms-messages--input) to two.
- *
- * Using data-pdforms-messages-prepend we could prepend the message to placeholder found in previous steps.
- * Using data-pdforms-messages-tagname we could change the default span (p in case of global messages) element.
- * Using data-pdforms-messages--global on elem we could force the message to be displayed in global message placeholder.
- */
-pdForms.addMessage = function(elem, message, type, isAjaxRuleMessage) {
-	if (! type in pdForms.constants) {
-		type = pdForms.constants.ERROR_MESSAGE;
-	}
-
-	var $placeholder = $(elem).closest('.pdforms-messages--input');
-	if ($placeholder.length === 0) {
-		$placeholder = $(elem).closest('p');
-	}
-
-	if ($placeholder.length) {
-		$placeholder.addClass('pdforms-' + type);
-	}
-
-	if (! message) {
-		return false;
-	}
-
-	var tagName = 'label';
-	var className = 'inp-' + type;
-	var globalMessage = $(elem).data('pdforms-messages--global') || false;
-
-	var $msg = '';
-
-	if ((globalMessage || $placeholder.length === 0) && ($placeholder = $(elem).closest('form').find('.pdforms-messages--global')).length) {
-		tagName = 'p';
-		globalMessage = true;
-	}
-
-	if ($placeholder.length) {
-		// global message or non-error message or first error message
-		if (globalMessage || type !== pdForms.constants.ERROR_MESSAGE || (type === pdForms.constants.ERROR_MESSAGE && ! $placeholder.hasClass(type))) {
-			tagName = $placeholder.data('pdforms-messages-tagname') || tagName;
-			className = (tagName === 'p') ? 'message message--' + type : className;
-
-			$msg = $('<' + tagName + ' class="' + className + ' pdforms-message" data-elem="' + $(elem).attr('name') + '">' + message + '</' + tagName + '>');
-
-			if (isAjaxRuleMessage) {
-				$msg.attr('data-ajax-rule', true);
-			}
-
-			if (tagName === 'label') {
-				$msg.attr('for', $(elem).attr('id'));
-			}
-
-			$placeholder.data('pdforms-messages-prepend') ? $placeholder.prepend($msg) : $placeholder.append($msg);
-		}
-	}
-};
-
-
-/**
- * Removes all messages associated with input. By default removes messages associated with ajax rules as well, but that
- * can be changed not to.
- */
-pdForms.removeMessages = function(elem, removeAjaxRulesMessages) {
-	var name = $(elem).attr('name');
-
-	// Default value should be true
-	if (typeof removeAjaxRulesMessages === 'undefined') {
-		removeAjaxRulesMessages = true;
-	}
-
-	// Find placeholders for input (input and global)
-	var $placeholder = $(elem).closest('.pdforms-messages--input');
-	if ($placeholder.length === 0) {
-		$placeholder = $(elem).closest('p');
-	}
-	var $globalPlaceholder = $(elem).closest('form').find('.pdforms-messages--global');
-
-
-	// Find all messages associated with the elem
-	var $messages = {
-		'input': $placeholder.find('.pdforms-message'),
-		'global': $globalPlaceholder.find('.pdforms-message')
 	};
-	var $removeMessages = $([]);
 
-	// Filter all messages for deleting
-	for (var key in $messages) {
-		if ($messages.hasOwnProperty(key)) {
+	pdForms.ajaxCallbacks = pdForms.ajaxCallbacks || {};
 
-			$messages[key] = $messages[key].filter(function() {
-				var isElemAssociatedMessage = $(this).data('elem') === name;
-				var isAjaxRuleMessage = $(this).data('ajax-rule');
-
-				// Remove ajax rules associated messages only if removeAjaxRulesMessages is true
-				var shouldRemove = isElemAssociatedMessage && (removeAjaxRulesMessages || (! removeAjaxRulesMessages && ! isAjaxRuleMessage));
-
-				if (shouldRemove) {
-					$removeMessages = $removeMessages.add(this);
+	/**
+	 * Fill in values into inputs defined in arg.inputs if the value is defined in payload.
+	 */
+	pdForms.ajaxFillDependentInputs = function(elem, payload, arg) {
+		if (typeof payload === 'object' && payload.valid && typeof payload.dependentInputs === 'object' && typeof arg === 'object' && typeof arg.dependentInputs === 'object') {
+			for (var inputName in arg.dependentInputs) {
+				if (! arg.dependentInputs.hasOwnProperty(inputName)) {
+					continue;
 				}
 
-				return ! shouldRemove;
-			});
+				var inputId = arg.dependentInputs[inputName];
 
+				if (! payload.dependentInputs.hasOwnProperty(inputId)) {
+					continue;
+				}
+
+				var input = document.getElementById(inputId);
+
+				if (input && ! input.value) {
+					$(input)
+						.val(payload.dependentInputs[inputId])
+						.trigger('change')
+						.trigger('validate.pdForms');
+				}
+			}
 		}
-	}
-
-	// If there is no message remaining in .pdforms-messages--input placeholder, then remove the placeholder class as well.
-	if ($messages.input.length === 0) {
-		$placeholder.removeClass(String(pdForms.constants));
-	}
-
-	// Remove the messages
-	$removeMessages.remove();
-};
-
-
-pdForms.getAjaxUrlParameters = function(elem, arg, val, value, callback) {
-	var parameters = {
-		inputValue: val,
-		dependentInputs: {}
 	};
 
-	for (var i in arg.dependentInputs) {
-		parameters.dependentInputs[i] = {
-			htmlId: arg.dependentInputs[i],
-			value: document.getElementById(arg.dependentInputs[i]).value
+
+	/**
+	 * Display message. Either input associated or (if appropriate selector not found) as "global" form message.
+	 * Message placeholding:
+	 * 	1. First we try to find elements parent .pdforms-messages--input
+	 * 	2. If there is not any, then try to find closest p
+	 * 	3. If still no success, try to find .pdforms-messages--global
+	 *
+	 * If two or more inputs with validation rules are in same message placeholder (eg. <p> or .pdforms-messages--input), the
+	 * validation won't work as expected - class .error will be determined by last validated input in the placeholder and
+	 * messages may disappear unexpectedly :) In that case, you might be better with using .pdforms-messages--global or splitting
+	 * the <p> (.pdforms-messages--input) to two.
+	 *
+	 * Using data-pdforms-messages-prepend we could prepend the message to placeholder found in previous steps.
+	 * Using data-pdforms-messages-tagname we could change the default span (p in case of global messages) element.
+	 * Using data-pdforms-messages--global on elem we could force the message to be displayed in global message placeholder.
+	 */
+	pdForms.addMessage = function(elem, message, type, isAjaxRuleMessage) {
+		if (! type in pdForms.constants) {
+			type = pdForms.constants.ERROR_MESSAGE;
 		}
-	}
 
-	return parameters;
-};
+		var $placeholder = $(elem).closest('.pdforms-messages--input');
+		if ($placeholder.length === 0) {
+			$placeholder = $(elem).closest('p');
+		}
+
+		if ($placeholder.length) {
+			$placeholder.addClass('pdforms-' + type);
+		}
+
+		if (! message) {
+			return false;
+		}
+
+		var tagName = 'label';
+		var className = 'inp-' + type;
+		var globalMessage = $(elem).data('pdforms-messages--global') || false;
+
+		var $msg = '';
+
+		if ((globalMessage || $placeholder.length === 0) && ($placeholder = $(elem).closest('form').find('.pdforms-messages--global')).length) {
+			tagName = 'p';
+			globalMessage = true;
+		}
+
+		if ($placeholder.length) {
+			// global message or non-error message or first error message
+			if (globalMessage || type !== pdForms.constants.ERROR_MESSAGE || (type === pdForms.constants.ERROR_MESSAGE && ! $placeholder.hasClass(type))) {
+				tagName = $placeholder.data('pdforms-messages-tagname') || tagName;
+				className = (tagName === 'p') ? 'message message--' + type : className;
+
+				$msg = $('<' + tagName + ' class="' + className + ' pdforms-message" data-elem="' + $(elem).attr('name') + '">' + message + '</' + tagName + '>');
+
+				if (isAjaxRuleMessage) {
+					$msg.attr('data-ajax-rule', true);
+				}
+
+				if (tagName === 'label') {
+					$msg.attr('for', $(elem).attr('id'));
+				}
+
+				$placeholder.data('pdforms-messages-prepend') ? $placeholder.prepend($msg) : $placeholder.append($msg);
+			}
+		}
+	};
 
 
-/**
- * pd-rules
- */
-Nette.validators.PdFormsRules_containsNumber = function(elem, arg, val) {
-	return Nette.validators.regexp(elem, String(/\d+/), val);
-};
+	/**
+	 * Removes all messages associated with input. By default removes messages associated with ajax rules as well, but that
+	 * can be changed not to.
+	 */
+	pdForms.removeMessages = function(elem, removeAjaxRulesMessages) {
+		var name = $(elem).attr('name');
 
-Nette.validators.PdFormsRules_phone = function(elem, arg, val) {
-	return Nette.validators.regexp(elem, String(/^\+[0-9]{3} ?[1-9][0-9]{2} ?[0-9]{3} ?[0-9]{3}$/), val);
-};
+		// Default value should be true
+		if (typeof removeAjaxRulesMessages === 'undefined') {
+			removeAjaxRulesMessages = true;
+		}
 
-Nette.validators.PdFormsRules_ajax = function(elem, arg, val, value, callback) {
+		// Find placeholders for input (input and global)
+		var $placeholder = $(elem).closest('.pdforms-messages--input');
+		if ($placeholder.length === 0) {
+			$placeholder = $(elem).closest('p');
+		}
+		var $globalPlaceholder = $(elem).closest('form').find('.pdforms-messages--global');
+
+
+		// Find all messages associated with the elem
+		var $messages = {
+			'input': $placeholder.find('.pdforms-message'),
+			'global': $globalPlaceholder.find('.pdforms-message')
+		};
+		var $removeMessages = $([]);
+
+		// Filter all messages for deleting
+		for (var key in $messages) {
+			if ($messages.hasOwnProperty(key)) {
+
+				$messages[key] = $messages[key].filter(function() {
+					var isElemAssociatedMessage = $(this).data('elem') === name;
+					var isAjaxRuleMessage = $(this).data('ajax-rule');
+
+					// Remove ajax rules associated messages only if removeAjaxRulesMessages is true
+					var shouldRemove = isElemAssociatedMessage && (removeAjaxRulesMessages || (! removeAjaxRulesMessages && ! isAjaxRuleMessage));
+
+					if (shouldRemove) {
+						$removeMessages = $removeMessages.add(this);
+					}
+
+					return ! shouldRemove;
+				});
+
+			}
+		}
+
+		// If there is no message remaining in .pdforms-messages--input placeholder, then remove the placeholder class as well.
+		if ($messages.input.length === 0) {
+			$placeholder.removeClass(String(pdForms.constants));
+		}
+
+		// Remove the messages
+		$removeMessages.remove();
+	};
+
+
+	pdForms.getAjaxUrlParameters = function(elem, arg, val, value, callback) {
+		var parameters = {
+			inputValue: val,
+			dependentInputs: {}
+		};
+
+		for (var i in arg.dependentInputs) {
+			parameters.dependentInputs[i] = {
+				htmlId: arg.dependentInputs[i],
+				value: document.getElementById(arg.dependentInputs[i]).value
+			}
+		}
+
+		return parameters;
+	};
+
+
+	/**
+	 * pd-rules
+	 */
+	Nette.validators.PdFormsRules_containsNumber = function(elem, arg, val) {
+		return Nette.validators.regexp(elem, String(/\d+/), val);
+	};
+
+	Nette.validators.PdFormsRules_phone = function(elem, arg, val) {
+		return Nette.validators.regexp(elem, String(/^\+[0-9]{3} ?[1-9][0-9]{2} ?[0-9]{3} ?[0-9]{3}$/), val);
+	};
+
+	Nette.validators.PdFormsRules_ajax = function(elem, arg, val, value, callback) {
 	if (typeof callback === 'undefined') {
 		callback = 'PdFormsRules_ajax';
 	}
 
-	var parameters = pdForms.getAjaxUrlParameters(elem, arg, val, value, callback);
+		var parameters = pdForms.getAjaxUrlParameters(elem, arg, val, value, callback);
 
-	$.nette.ajax(
-		pdForms.getAjaxRequestSettings(elem, callback, arg, parameters)
-	);
+		$.nette.ajax(
+			pdForms.getAjaxRequestSettings(elem, callback, arg, parameters)
+		);
 
-	return true;
-};
-
-Nette.validators.PdFormsRules_czechCompanyIdentifier = function(elem, arg, val) {
-	var a = 0;
-	var b = 0;
-
-	val = val.replace(/\s/g, '');
-
-	if  (val.length !== 8 || ! Nette.validators.regexp(elem, String(/\d+/), val)) {
-		return false;
-	}
-
-	for (var i = 0 ; i < 7; i++) {
-		a += parseInt(val[i] * (8 - i));
-	}
-
-	a = a % 11;
-	if (a === 0) {
-		b = 1;
-	} else if (a === 1) {
-		b = 0;
-	} else {
-		b = 11 - a;
-	}
-
-	return parseInt(val[7]) === b;
-};
-
-
-/*
- * Trochu špinavý trik? Kvůli snippetům uvnitř formuláře je potřeba navázat callbacky takovým způsobem, aby bylo možné
- * je později odpojit, viz Nette.addEvent níže. Extension validation v nette.ajax ale pro netteForm verze 2.3 (nebo
- * neuvedené) kontroluje onsubmit property na formuláři a tu volá pro zvalidování (viz původní Nette.addEvent metoda).
- * Od verze 2.4 ale (v případě, že onsubmit není, jinak použije funkci v onsubmit) volá validaci formuláře napřímo
- * pomocí Nette.validateForm. Protože podmínka je na undefined nebo "2.3", jakýkoli jiný řetězec, stačí uvést třeba toto
- * a všechno funguje jak má. Snad. Don't panic.
- */
-Nette.version = '2.3-pd';
-
-
-/**
- * Display error message.
- */
-Nette.addError = function(elem, message) {
-	pdForms.addMessage(elem, message, pdForms.constants.ERROR_MESSAGE);
-};
-
-
-/**
- * Add event to element using jQuery namespaces
- */
-Nette.addEvent = function(element, on, callback) {
-	$(element).on(on + '.netteForms', callback);
-};
-
-
-/**
- *
- */
-Nette.validateControl = function(elem, rules, onlyCheck) {
-
-	if (!elem.nodeName) { // RadioNodeList
-		elem = elem[0];
-	}
-	rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
-
-	// no rules -> skip element validation
-	if (rules.length === 0) {
 		return true;
-	}
-
-	// convert arg property in rules into Nette format
-	rules = pdForms.normalizeRules(rules);
-
-	return pdForms.validateControl(elem, rules, onlyCheck);
-};
-
-
-/**
- *
- */
-Nette.toggleControl = function(elem, rules, success, firsttime, value) {
-	// convert arg property in rules into Nette format
-	rules = pdForms.normalizeRules(rules);
-
-	pdForms.Nette.toggleControl(elem, rules, success, firsttime, value);
-};
-
-
-/**
- * Setup handlers.
- */
-Nette.initForm = function (form) {
-	var $form = $(form);
-	var $submit = $form.find(':submit');
-	var $inputs = $form.find('input:not(:button, :reset), textarea, select').filter('[data-nette-rules], [data-validation-group]'); // validate only fields with rules or fields in group
-
-	$form.off('.netteForms');
-	$inputs.off('.pdForms .netteForms');
-
-	pdForms.Nette.initForm(form);
-
-	$inputs.on('focus.pdForms change.pdForms', function() {
-		$(this).data('ever-focused', true);
-	});
-
-	var validateInputApplied = function (e) {
-		$.proxy(pdForms.validateInput, this, e, $inputs)();
 	};
 
-	$inputs.filter(':not(:radio, :checkbox, select, [data-pdforms-validate-on])').on('validate.pdForms blur.pdForms', validateInputApplied);
-	$inputs.filter(':radio, :checkbox').on('validate.pdForms change.pdForms', validateInputApplied);
-	$inputs.filter('select').on('validate.pdForms blur.pdForms change.pdForms', validateInputApplied);
-	$inputs.filter('[data-pdforms-validate-on]').each(function() {
-		$(this).on('validate.pdForms ' + $(this).data('pdforms-validate-on') + '.pdForms', validateInputApplied);
-	});
-};
+	Nette.validators.PdFormsRules_czechCompanyIdentifier = function(elem, arg, val) {
+		var a = 0;
+		var b = 0;
+
+		val = val.replace(/\s/g, '');
+
+		if  (val.length !== 8 || ! Nette.validators.regexp(elem, String(/\d+/), val)) {
+			return false;
+		}
+
+		for (var i = 0 ; i < 7; i++) {
+			a += parseInt(val[i] * (8 - i));
+		}
+
+		a = a % 11;
+		if (a === 0) {
+			b = 1;
+		} else if (a === 1) {
+			b = 0;
+		} else {
+			b = 11 - a;
+		}
+
+		return parseInt(val[7]) === b;
+	};
+
+
+	/**
+	 * Optional rules are defined using "optional" property in "arg". We have to convert arg into Nette format before
+	 * validating. This means removing all properties but data from arg and storing them elsewhere.
+	 */
+	Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
+		elem = elem.tagName ? elem : elem[0]; // RadioNodeList
+		rules = rules || Nette.parseJSON(elem.getAttribute('data-nette-rules'));
+
+		// no rules -> skip element validation
+		if (rules.length === 0) {
+			return true;
+		}
+
+		// convert arg property in rules into Nette format
+		rules = pdForms.normalizeRules(rules);
+
+		return pdForms.validateControl(elem, rules, onlyCheck, value, emptyOptional);
+	};
+
+
+	/**
+	 * See annotation above.
+	 */
+	Nette.toggleControl = function(elem, rules, success, firsttime, value) {
+		// convert arg property in rules into Nette format
+		rules = pdForms.normalizeRules(rules);
+
+		pdForms.Nette.toggleControl(elem, rules, success, firsttime, value);
+	};
+
+
+	/**
+	 * Messages in pdForms are always object, so we push message.invalid.
+	 */
+	Nette.addError = function(elem, message) {
+		Nette.formErrors.push({
+			element: elem,
+			message: message.invalid
+		});
+	};
+
+
+	/**
+	 * As a side effect of live validation, errors are shown directly in validateControl. This method is used only for
+	 * focusing the first element with error.
+	 */
+	Nette.showFormErrors = function(form, errors) {
+		var focusElem;
+
+		for (var i = 0; i < errors.length; i++) {
+			var elem = errors[i].element;
+
+			if (!focusElem && elem.focus) {
+				focusElem = elem;
+				break;
+			}
+		}
+
+		if (focusElem) {
+			focusElem.focus();
+		}
+	};
+
+
+	/**
+	 * Add event listener which delegates the event to given selector.
+	 */
+	var addDelegatedEventListener = function(element, eventName, selector, callback) {
+		var events = eventName.split(' ');
+
+		for (var i = 0; i < events.length; i++) {
+			element.addEventListener(events[i], function(e) {
+				if (e.target.matches(selector)) {
+					callback.call(element, e);
+				}
+			});
+		}
+	};
+
+
+	/**
+	 * Setup handlers.
+	 */
+	Nette.initForm = function (form) {
+		pdForms.Nette.initForm(form);
+
+		addDelegatedEventListener(form, 'focusin change', 'select, textarea, input:not([type="submit"]):not([type="reset"])', function(e) {
+			e.target.setAttribute('data-pdforms-ever-focused', true);
+		});
+
+		addDelegatedEventListener(form, 'focusout', 'select, textarea, input:not([type="radio"]):not([type="checkbox"])', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'change', 'input[type="radio"], input[type="checkbox"], select', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate', 'select, textarea, input:not([type="submit"]):not([type="reset"])', pdForms.liveValidation);
+
+
+		pdformsValidateOnArr = Array.prototype.slice.call(form.elements);
+		pdformsValidateOnArr = pdformsValidateOnArr.filter(function(element) {
+			return element.matches('[data-pdforms-validate-on]');
+		});
+
+		for (var i = 0; i < pdformsValidateOnArr.length; i++) {
+			(function() {
+				var el = pdformsValidateOnArr[i];
+				var eventName = el.getAttribute('data-pdforms-validate-on');
+
+				form.addEventListener(eventName, function(e) {
+					if (e.target === el) {
+						pdForms.liveValidation.call(form, e);
+					}
+				})
+			})();
+		}
+	};
+
+
+	return pdForms;
+}));

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -531,44 +531,6 @@
 
 
 	/**
-	 * pd-rules
-	 */
-	Nette.validators.PdFormsRules_containsNumber = function(elem, arg, val) {
-		return Nette.validators.regexp(elem, String(/\d+/), val);
-	};
-
-	Nette.validators.PdFormsRules_phone = function(elem, arg, val) {
-		return Nette.validators.regexp(elem, String(/^\+[0-9]{3} ?[1-9][0-9]{2} ?[0-9]{3} ?[0-9]{3}$/), val);
-	};
-
-	Nette.validators.PdFormsRules_czechCompanyIdentifier = function(elem, arg, val) {
-		var a = 0;
-		var b = 0;
-
-		val = val.replace(/\s/g, '');
-
-		if  (val.length !== 8 || ! Nette.validators.regexp(elem, String(/\d+/), val)) {
-			return false;
-		}
-
-		for (var i = 0 ; i < 7; i++) {
-			a += parseInt(val[i] * (8 - i));
-		}
-
-		a = a % 11;
-		if (a === 0) {
-			b = 1;
-		} else if (a === 1) {
-			b = 0;
-		} else {
-			b = 11 - a;
-		}
-
-		return parseInt(val[7]) === b;
-	};
-
-
-	/**
 	 * Optional rules are defined using "optional" property in "arg". We have to convert arg into Nette format before
 	 * validating. This means removing all properties but data from arg and storing them elsewhere.
 	 */

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -405,7 +405,7 @@
 			return false;
 		}
 
-		if (! type in pdForms.constants) {
+		if (Object.values(pdForms.constants).indexOf(type) === -1) {
 			type = pdForms.constants.ERROR_MESSAGE;
 		}
 

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -62,9 +62,9 @@
 	 * Constants for messages. Used in CSS class names.
 	 */
 	pdForms.constants = {
-		ERROR_MESSAGE: 'error',
-		INFO_MESSAGE: 'info',
-		OK_MESSAGE: 'valid'
+		MESSAGE_ERROR: 'error',
+		MESSAGE_INFO: 'info',
+		MESSAGE_VALID: 'valid'
 	};
 
 
@@ -165,7 +165,7 @@
 				// has to be here and not inside validateControl as it should add ok class only if whole input is valid (not only parts of condional rule etc.)
 				if (ret && ! hasAjaxRule) {
 					// add pdforms-valid class name if the input is valid
-					pdForms.addMessage(elem, null, pdForms.constants.OK_MESSAGE);
+					pdForms.addMessage(elem, null, pdForms.constants.MESSAGE_VALID);
 				}
 			}
 		});
@@ -211,10 +211,10 @@
 						if (rule.msg.invalid) {
 							pdForms.removeMessages(elem, true);
 						}
-						pdForms.addMessage(elem, rule.msg.invalid, rule.isOptional ? pdForms.constants.INFO_MESSAGE : pdForms.constants.ERROR_MESSAGE);
+						pdForms.addMessage(elem, rule.msg.invalid, rule.isOptional ? pdForms.constants.MESSAGE_INFO : pdForms.constants.MESSAGE_ERROR);
 					}
 					else if (rule.msg.valid) {
-						pdForms.addMessage(elem, rule.msg.valid, pdForms.constants.OK_MESSAGE);
+						pdForms.addMessage(elem, rule.msg.valid, pdForms.constants.MESSAGE_VALID);
 					}
 				}
 
@@ -288,25 +288,25 @@
 				pdForms.removeMessages(elem, true);
 
 				if (status in msg && msg[status]) {
-					var msgType = pdForms.constants.INFO_MESSAGE;
+					var msgType = pdForms.constants.MESSAGE_ERROR;
 
 					if (typeof payload === 'object' && payload.messageType) {
 						msgType = payload.messageType;
 					} else if (status === 'invalid' && ! isOptional) {
-						msgType = pdForms.constants.ERROR_MESSAGE;
+						msgType = pdForms.constants.MESSAGE_ERROR;
 					} else if (status === 'valid') {
-						msgType = pdForms.constants.OK_MESSAGE;
+						msgType = pdForms.constants.MESSAGE_VALID;
 					}
 
-					if (isOptional && msgType === pdForms.constants.ERROR_MESSAGE) {
-						msgType = pdForms.constants.INFO_MESSAGE;
+					if (isOptional && msgType === pdForms.constants.MESSAGE_ERROR) {
+						msgType = pdForms.constants.MESSAGE_INFO;
 					}
 
 					pdForms.addMessage(elem, msg[status], msgType, true);
 				}
 				else if (status === 'valid') {
 					// add pdforms-valid class name if the input is valid and no message is specified
-					pdForms.addMessage(elem, null, pdForms.constants.OK_MESSAGE, true);
+					pdForms.addMessage(elem, null, pdForms.constants.MESSAGE_VALID, true);
 				}
 			}
 
@@ -406,7 +406,7 @@
 		}
 
 		if (Object.values(pdForms.constants).indexOf(type) === -1) {
-			type = pdForms.constants.ERROR_MESSAGE;
+			type = pdForms.constants.MESSAGE_ERROR;
 		}
 
 		placeholder.elem.classList ?
@@ -425,7 +425,7 @@
 		}
 
 		// global message or non-error message or first error message
-		if (placeholder.isGlobal || type !== pdForms.constants.ERROR_MESSAGE || (type === pdForms.constants.ERROR_MESSAGE && ((' ' + placeholder.elem.className + ' ').indexOf(' ' + type + ' ') === -1))) {
+		if (placeholder.isGlobal || type !== pdForms.constants.MESSAGE_ERROR || (type === pdForms.constants.MESSAGE_ERROR && ((' ' + placeholder.elem.className + ' ').indexOf(' ' + type + ' ') === -1))) {
 			tagName = placeholder.elem.getAttribute('data-pdforms-messages-tagname') || tagName;
 			className = (tagName === 'p') ? 'message message--' + type : className;
 

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 2.0.0
+ * @version 3.0.0
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '2.0.0';
+	pdForms.version = '3.0.0';
 
 
 	/**

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -623,16 +623,12 @@
 
 			if (! everFocused) {
 				e.target.setAttribute('data-pdforms-ever-focused', true);
-
-				// When tabbing through fields, we want to validate them once even though no change event happend
-				// If change event happened, then ! everFocused would by false in focusout callback
-				if (e.type === 'focusout') {
-					pdForms.liveValidation.call(form, e);
-				}
 			}
 		});
 
-		addDelegatedEventListener(form, 'validate change',   'select, textarea, input:not([type="submit"]):not([type="reset"])', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate focusout',        'textarea, input:not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"])', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate focusout change', 'select', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate change',          'input[type="checkbox"], input[type="radio"]', pdForms.liveValidation);
 
 		// Validation on custom events
 		var pdformsValidateOnArr = Array.prototype.slice.call(form.elements);

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -198,12 +198,17 @@
 				};
 			}
 
-			var condition = !!rule.rules;
-			var valid = pdForms.Nette.validateControl(elem, [rule], ! condition || onlyCheck, value, emptyOptional);
+			if (rule.op === 'optional') {
+				emptyOptional = !Nette.validateRule(elem, ':filled', null, value);
+				continue;
+			}
 
-			// if rule is ajax, then do not write any message
+			var isCondition = !!rule.rules;
+			var valid = pdForms.Nette.validateControl(elem, [rule], ! isCondition || onlyCheck, value, emptyOptional);
+
 			if (! rule.isAjax) {
-				if (! onlyCheck) {
+				// write message and add error to form
+				if (! onlyCheck && ! isCondition) {
 					if (! valid) {
 						// if the rule is sync and we have a new message, we need to remove previous messages
 						// (including ajax rules associated); checking for message presence ensures that conditional rules
@@ -212,18 +217,20 @@
 						if (rule.msg.invalid) {
 							pdForms.removeMessages(elem, true);
 						}
+
 						pdForms.addMessage(elem, rule.msg.invalid, rule.isOptional ? pdForms.constants.MESSAGE_INFO : pdForms.constants.MESSAGE_ERROR);
+
+						if (! rule.isOptional) {
+							Nette.addError(elem, rule.msg.invalid);
+						}
 					}
 					else if (rule.msg.valid) {
 						pdForms.addMessage(elem, rule.msg.valid, pdForms.constants.MESSAGE_VALID);
 					}
 				}
 
+				// return value
 				if (! valid && ! rule.isOptional) {
-					if (! onlyCheck) {
-						Nette.addError(elem, rule.msg.invalid);
-					}
-
 					return valid;
 				}
 			}

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -143,12 +143,12 @@
 	 */
 	pdForms.liveValidation = function(e) {
 		var validate = [e.target];
-		var groupName = e.target.getAttribute('data-validation-group');
+		var groupName = e.target.getAttribute('data-pdforms-validation-group');
 
 		if (groupName) {
 			var elems = e.target.form.elements;
 			for (var i = 0; i < elems.length; i++) {
-				if (elems[i] !== e.target && elems[i].getAttribute('data-validation-group') === groupName) {
+				if (elems[i] !== e.target && elems[i].getAttribute('data-pdforms-validation-group') === groupName) {
 					validate.push(elems[i]);
 				}
 			}

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -292,8 +292,8 @@
 
 					if (typeof payload === 'object' && payload.messageType) {
 						msgType = payload.messageType;
-					} else if (status === 'invalid' && ! isOptional) {
-						msgType = pdForms.constants.MESSAGE_ERROR;
+					} else if (status === 'timeout') {
+						msgType = pdForms.constants.MESSAGE_INFO;
 					} else if (status === 'valid') {
 						msgType = pdForms.constants.MESSAGE_VALID;
 					}

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -198,7 +198,8 @@
 				};
 			}
 
-			var valid = pdForms.Nette.validateControl(elem, [rule], onlyCheck, value, emptyOptional);
+			var condition = !!rule.rules;
+			var valid = pdForms.Nette.validateControl(elem, [rule], ! condition || onlyCheck, value, emptyOptional);
 
 			// if rule is ajax, then do not write any message
 			if (! rule.isAjax) {
@@ -219,6 +220,10 @@
 				}
 
 				if (! valid && ! rule.isOptional) {
+					if (! onlyCheck) {
+						Nette.addError(elem, rule.msg.invalid);
+					}
+
 					return valid;
 				}
 			}
@@ -558,17 +563,6 @@
 		rules = pdForms.normalizeRules(rules);
 
 		pdForms.Nette.toggleControl(elem, rules, success, firsttime, value);
-	};
-
-
-	/**
-	 * Messages in pdForms are always object, so we push message.invalid.
-	 */
-	Nette.addError = function(elem, message) {
-		Nette.formErrors.push({
-			element: elem,
-			message: message.invalid
-		});
 	};
 
 

--- a/src/assets/pdForms.polyfills.js
+++ b/src/assets/pdForms.polyfills.js
@@ -1,0 +1,30 @@
+/**
+ * @name pdForms.polyfills
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * Polyfills required for support in IE9+.
+ */
+(function() {
+
+	if (! Element.prototype.matches) {
+		Element.prototype.matches =
+			Element.prototype.msMatchesSelector ||
+			Element.prototype.webkitMatchesSelector;
+	}
+
+
+	if (! Element.prototype.closest) {
+		Element.prototype.closest = function(s) {
+			var el = this;
+
+			do {
+				if (el.matches(s)) {
+					return el;
+				}
+				el = el.parentElement || el.parentNode;
+			} while (el !== null && el.nodeType === 1);
+
+			return null;
+		};
+	}
+})();

--- a/src/assets/pdForms.polyfills.js
+++ b/src/assets/pdForms.polyfills.js
@@ -27,4 +27,14 @@
 			return null;
 		};
 	}
+
+
+	if (! Object.values) {
+		Object.values = function (obj) {
+			return Object.keys(obj).map(function(i) {
+				return obj[i];
+			});
+		}
+	}
+
 })();

--- a/src/assets/validators/nette.ajax/pdForms.getAjaxRequestSettings.js
+++ b/src/assets/validators/nette.ajax/pdForms.getAjaxRequestSettings.js
@@ -1,0 +1,42 @@
+/**
+ * @name pdForms.getAsyncRequestSetting
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * This script is part of pdForms library. It implements helper function returning settings for nette ajax request based
+ * on passed parameters. It can be directly used as a parameter for $.nette.ajax() function.
+ */
+(function () {
+
+	var pdForms = window.pdForms || {};
+
+	pdForms.getAjaxRequestSettings = function(elem, op, arg, data) {
+		return {
+			url: arg.ajaxUrl,
+			data: (data ? data : null),
+			timeout: 5000,
+			spinner: '.pdforms-ajax-spinner--' + elem.id,
+			off: ['snippets', 'history', 'unique', 'abort'],
+			beforeSend: function(jqXHR, settings) {
+				elem.classList ?
+					elem.classList.add('inp-loading') :
+					elem.className += ' inp-loading';
+			},
+			success: function(payload) {
+				var status = payload.status || (payload.valid ? 'valid' : 'invalid');
+
+				pdForms.ajaxEvaluate(elem, op, status, payload, arg);
+			},
+			error: function(jqXHR, status, error, settings) {
+				pdForms.ajaxEvaluate(elem, op, error, undefined, arg);
+			},
+			complete: function(jqXHR, status, settings) {
+				elem.classList ?
+					elem.classList.remove('inp-loading') :
+					elem.className = (' ' + elem.className + ' ').replace(' inp-loading ', ' ').trim();
+			}
+		};
+	};
+
+	window.pdForms = pdForms;
+
+})();

--- a/src/assets/validators/nette.ajax/pdForms.validator.ajax.js
+++ b/src/assets/validators/nette.ajax/pdForms.validator.ajax.js
@@ -1,0 +1,23 @@
+/**
+ * @name pdForms.validator.ajax
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * Implementation for AJAX validator using nette ajax library.
+ */
+(function() {
+
+	Nette.validators.PdFormsRules_ajax = function(elem, arg, val, value, callback) {
+		if (typeof callback === 'undefined') {
+			callback = 'PdFormsRules_ajax';
+		}
+
+		var parameters = pdForms.getAjaxUrlParameters(elem, arg, val, value, callback);
+
+		$.nette.ajax(
+			pdForms.getAjaxRequestSettings(elem, callback, arg, parameters)
+		);
+
+		return true;
+	};
+
+})();

--- a/src/assets/validators/pdForms.validator.containsNumber.js
+++ b/src/assets/validators/pdForms.validator.containsNumber.js
@@ -1,0 +1,14 @@
+/**
+ * @name pdForms.validator.containsNumber
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * Implementation for containsNumber validator. This validates if the text input contains any type of number.
+ * This could be used eg. for check if street in address contains house number.
+ */
+(function() {
+
+	Nette.validators.PdFormsRules_containsNumber = function(elem, arg, val) {
+		return Nette.validators.regexp(elem, String(/\d+/), val);
+	};
+
+})();

--- a/src/assets/validators/pdForms.validator.czechCompanyIdentifier.js
+++ b/src/assets/validators/pdForms.validator.czechCompanyIdentifier.js
@@ -1,0 +1,35 @@
+/**
+ * @name pdForms.validator.czechCompanyIdentifier
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * Implementation for czechCompanyIdentifier validator. This validator validates correct format of czech IČO.
+ */
+(function() {
+
+	Nette.validators.PdFormsRules_czechCompanyIdentifier  = function(elem, arg, val) {
+		var a = 0;
+		var b = 0;
+
+		val = val.replace(/\s/g, '');
+
+		if  (val.length !== 8 || ! Nette.validators.regexp(elem, String(/\d+/), val)) {
+			return false;
+		}
+
+		for (var i = 0 ; i < 7; i++) {
+			a += parseInt(val[i] * (8 - i));
+		}
+
+		a = a % 11;
+		if (a === 0) {
+			b = 1;
+		} else if (a === 1) {
+			b = 0;
+		} else {
+			b = 11 - a;
+		}
+
+		return parseInt(val[7]) === b;
+	};
+
+})();

--- a/src/assets/validators/pdForms.validator.phone.js
+++ b/src/assets/validators/pdForms.validator.phone.js
@@ -1,0 +1,13 @@
+/**
+ * @name pdForms.validator.phone
+ * @author Radek Šerý <radek.sery@peckadesign.cz>
+ *
+ * Implementation for phone validator.
+ */
+(function() {
+
+	Nette.validators.PdFormsRules_phone = function(elem, arg, val) {
+		return Nette.validators.regexp(elem, String(/^\+[0-9]{3} ?[1-9][0-9]{2} ?[0-9]{3} ?[0-9]{3}$/), val);
+	};
+
+})();


### PR DESCRIPTION
- Přepsání pro kompatibilitu s nette-forms 2.4.
- Odebrání závilosti na jQuery a nette ajax pro základní funkčnost pdForms.
- Nachystání validátoru pro DIČ s využitím jQuery a nette ajax.

### Release notes
- Kompatibilita s Nette Forms 2.4
- Funkční nahrazování placeholderů ve validačních zprávách (`%value`, `%\d+`)
- U asynchronních pravidel jsou automaticky vyplněny inputy, které jsou nastaveny v `arg.inputs` (případně `arg.data.inputs`) a jejichž hodnoty dojdou v `payload`. Dříve toto řešil manuálně callback pro danou validaci, např. `PdFormsRules_validTIN`.
- **BC breaky:**
    - Veškeré události vyvolávané přes pdForms jsou nově Vanilla JS, tj. nekompatibilní s jQuery událostmi. Je tedy nutné upravit navázání callbacků na vanilla JS, např. vyhledáním `validate.pdForms`, respektive i dalších událostí jQuery s namespace `.pdForms`.
    - Přejmenování `data-ever-focused` na `data-pdforms-ever-focused`, navíc se nepoužívá jQuery funkce `$.data()`, ale nastavuje se reálný atribut.
    - Přejmenování `data-validation-groudp` na `data-pdforms-validation-group`.
    - Nastavení `messageType` v `payload` u AJAXových validací má nejvyšší prioritu při nastavení `class` validační zprávy.
    - Atribut pro vypsání chybové zprávy jako globální je nyní `data-pdforms-messages-global`, omylem byla zanesena chyba, kdy název byl ~~`data-pdforms-messages--global`~~.
    - Odebrána interní metoda `toString` nad `pdForms.constants`, tj. již není možné volat `String(pdForms.constants)`.
    - Přejmenování konstant používaných pro class (`pdForms.constants`). Nově jsou to `MESSAGE_ERROR`, `MESSAGE_INFO` a `MESSAGE_VALID`.
