### PR TITLE
Oprava vyplnění `dependentInputs` dle reponse serveru

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.0.1
+ * @version 3.0.2
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.0.1';
+	pdForms.version = '3.0.2';
 
 
 	/**
@@ -357,7 +357,7 @@
 					var ev = document.createEvent('Event');
 					ev.initEvent('change', true, true);
 
-					input.value = payload[inputId];
+					input.value = payload.dependentInputs[inputId];
 					input.dispatchEvent(ev);
 				}
 			}


### PR DESCRIPTION
Oprava chybného přístupu k hodnotě k vyplnění v rámci `payload`. V podmínce o někoilk řádků výše byla kontrola správně, nicméně v samotném vyplnění byla chyba.