### PR TITLE
 #24 Nezobrazení validační zprávy v IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.0.2
+ * @version 3.0.3
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.0.2';
+	pdForms.version = '3.0.3';
 
 
 	/**
@@ -454,8 +454,8 @@
 			}
 
 			placeholder.elem.getAttribute('data-pdforms-messages-prepend') ?
-				placeholder.elem.prepend(msg) :
-				placeholder.elem.append(msg);
+				placeholder.elem.insertAdjacentElement('afterBegin', msg) :
+				placeholder.elem.insertAdjacentElement('beforeEnd', msg);
 		}
 	};
 


### PR DESCRIPTION
PR k úkolu #24

 - V IE nepodporované `ParentNode.append()` a `ParentNode.prepend()` metody jsou nahrazeny za `Element.insertAdjacentElement()`