### PR TITLE
26 Nefunkční Nette.initForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.0.3
+ * @version 3.0.4
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.0.3';
+	pdForms.version = '3.0.4';
 
 
 	/**

--- a/src/assets/validators/nette.ajax/pdForms.validator.ajax.js
+++ b/src/assets/validators/nette.ajax/pdForms.validator.ajax.js
@@ -7,6 +7,12 @@
 (function() {
 
 	Nette.validators.PdFormsRules_ajax = function(elem, arg, val, value, callback) {
+		// In case of $.nette.ajax being undefined, do not validate. This may happen on page load when Nette.initForm
+		// is called.
+		if (! $ || ! $.nette || ! $.nette.ajax) {
+			return true;
+		}
+
 		if (typeof callback === 'undefined') {
 			callback = 'PdFormsRules_ajax';
 		}


### PR DESCRIPTION
PR k úkolu #26

Ve vzácných případech mohlo dojít k situace, že Nette.initForm způsobila chybu v případě AJAXové validace. Výjimečně mohlo dojít k tomu, že JS událost DOMContentLoaded byla vyvolána dříve, než dojde ke zpracování již staženého JS. V tu chvíli event handler vyvolat inicializaci formuláře, která prostředníctvím Nette.toggleForm spustila AJAXovou validaci ve chvíli, kdy ještě $.nette bylo undefined.

Protože AJAXová validace vrací vždy `true`, není klíčové při `toggleForm` metodě vyvolávat request. Proto byla přidána podmínka, která ověřuje, že je `$.nette.ajax` definované.