### PR TITLE
peckadesign/pdproject5#2859 Aktualizace PHP pro pd/forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.*
 !.gitignore
 !.travis.yml
+composer.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: php
 
 php:
     - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
 
 script:
     - vendor/bin/phpcs src/ tests/ --ignore="assets/*" --standard=vendor/pd/coding-standard/src/PeckaCodingStandard/ruleset.xml
     - vendor/bin/phpcs src/ tests/ --ignore="assets/*" --standard=vendor/pd/coding-standard/src/PeckaCodingStandardStrict/ruleset.xml
-    - vendor/bin/phpstan analyse --level 7 src/
+    - vendor/bin/phpstan analyse --level 8 src/
     - vendor/bin/tester tests/
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/peckadesign/pdForms.svg?branch=master)](https://travis-ci.com/peckadesign/pdForms)
 [![Licence](https://img.shields.io/packagist/l/pd/forms.svg?style=flat-square)](https://packagist.org/packages/pd/forms)
+![coverage](https://img.shields.io/badge/coverage-75%25-green)
 
 # Pd\Form\Rules + pdForms.js
 Knihovna poskytuje nástroje, pomocí kterých je možné zaregistrovat vlastní validační pravidla do Nette\Forms a navíc poskytuje podporu pro live, měkkou a ajaxovou validaci, které lze zaregistrovat  v PHP kódu. Řešení vychází z nativní podpory Nette pro custom validační pravidla https://pla.nette.org/cs/vlastni-validacni-pravidla, ale nespoléhá ani nekopíruje interní quirks Nette frameworku.

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
 		}
 	],
 	"require": {
-		"php": "7.1.*",
+		"php": "^7.1",
 		"ext-json": "*",
-		"nette/application": "2.4.*",
-		"nette/forms": "2.4.*",
-		"nette/di": "2.4.*",
-		"nette/utils": "2.*",
-		"pd/utils": "1.*"
+		"nette/application": "~2.4",
+		"nette/forms": "~2.4",
+		"nette/di": "~2.4",
+		"nette/utils": "~2.4",
+		"pd/utils": "^1.0"
 	},
 	"require-dev": {
-		"nette/tester": "2.*",
+		"nette/tester": "~2.3.2",
 		"mockery/mockery": "^1.0",
 		"pd/coding-standard": "1.21.*",
-		"phpstan/phpstan-shim": "0.10.*"
+		"phpstan/phpstan": "0.12.18"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/RuleOptions.php
+++ b/src/RuleOptions.php
@@ -15,7 +15,7 @@ final class RuleOptions implements \JsonSerializable
 	public const MESSAGE_VALID = 'valid';
 
 	/**
-	 * @var array
+	 * @var array<string|null>
 	 */
 	private $validationMessages = [
 		self::STATUS_INVALID => NULL,
@@ -44,12 +44,12 @@ final class RuleOptions implements \JsonSerializable
 	private $validationService;
 
 	/**
-	 * @var array
+	 * @var \Nette\Forms\Controls\BaseControl[]
 	 */
 	private $dependentInputCollection = [];
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	private $contextStorage = [];
 
@@ -80,6 +80,14 @@ final class RuleOptions implements \JsonSerializable
 		$this->validationService = $validationService;
 
 		return $this;
+	}
+
+
+	private function checkValidationState(?\Pd\Forms\Validation\ValidationServiceInterface $validationService = NULL): void
+	{
+		if ( ! $this->optional && $validationService === NULL) {
+			throw new \RuntimeException('Validation service must be defined for required rule');
+		}
 	}
 
 
@@ -123,6 +131,7 @@ final class RuleOptions implements \JsonSerializable
 	/**
 	 * @param string $name
 	 * @param mixed $context
+	 *
 	 * @throws \Pd\Forms\Exceptions\InvalidKeyException
 	 */
 	public function addContext(string $name, $context): self
@@ -163,6 +172,9 @@ final class RuleOptions implements \JsonSerializable
 	}
 
 
+	/**
+	 * @return array<mixed>
+	 */
 	public function getNormalizedDependentInputs(): array
 	{
 		return \array_map(static function (\Nette\Forms\Controls\BaseControl $control): array {
@@ -174,6 +186,9 @@ final class RuleOptions implements \JsonSerializable
 	}
 
 
+	/**
+	 * @return array<mixed>
+	 */
 	public function jsonSerialize()
 	{
 		$serialized = [
@@ -207,13 +222,5 @@ final class RuleOptions implements \JsonSerializable
 		}
 
 		return $serialized;
-	}
-
-
-	private function checkValidationState(?\Pd\Forms\Validation\ValidationServiceInterface $validationService = NULL): void
-	{
-		if ( ! $this->optional && $validationService === NULL) {
-			throw new \RuntimeException('Validation service must be defined for required rule');
-		}
 	}
 }

--- a/src/RuleOptionsFactory.php
+++ b/src/RuleOptionsFactory.php
@@ -32,6 +32,10 @@ final class RuleOptionsFactory
 	}
 
 
+	/**
+	 * @param string $netteRule
+	 * @param mixed|null $ruleArguments
+	 */
 	public function createNetteOptional(string $netteRule, $ruleArguments = NULL): \Pd\Forms\RuleOptions
 	{
 		$options = new \Pd\Forms\RuleOptions($this->translator, TRUE);

--- a/src/Validation/ValidationControllerInterface.php
+++ b/src/Validation/ValidationControllerInterface.php
@@ -4,7 +4,12 @@ namespace Pd\Forms\Validation;
 
 interface ValidationControllerInterface
 {
+	/**
+	 * @param mixed $inputValue
+	 * @param array<string> $dependentInputs
+	 */
 	public function actionDefault($inputValue = NULL, array $dependentInputs = []): void;
+
 
 	public function getValidationService(): \Pd\Forms\Validation\ValidationServiceInterface;
 }

--- a/src/Validation/ValidationResult.php
+++ b/src/Validation/ValidationResult.php
@@ -15,7 +15,7 @@ final class ValidationResult implements \JsonSerializable
 	private $status;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	private $dependentInputs;
 
@@ -44,6 +44,10 @@ final class ValidationResult implements \JsonSerializable
 	}
 
 
+	/**
+	 * @param string $name
+	 * @param mixed $value
+	 */
 	public function addDependentInput(string $name, $value): void
 	{
 		$this->dependentInputs[$name] = $value;
@@ -62,6 +66,9 @@ final class ValidationResult implements \JsonSerializable
 	}
 
 
+	/**
+	 * @return array<mixed>
+	 */
 	public function jsonSerialize()
 	{
 		$valid = [

--- a/src/Validation/ValidationServiceInterface.php
+++ b/src/Validation/ValidationServiceInterface.php
@@ -4,5 +4,9 @@ namespace Pd\Forms\Validation;
 
 interface ValidationServiceInterface
 {
+	/**
+	 * @param mixed $value
+	 * @param array<string> $dependentInputs
+	 */
 	public function validateInput($value, array $dependentInputs = []): \Pd\Forms\Validation\ValidationResult;
 }


### PR DESCRIPTION
peckadesign/pdproject5#2859

- minimální verze vendor balíků
- travis běží pro PHP <7.4
- code pro 7.4 "ready"

**TODO**: První musí jít release pd/utils, kde je podpora 7.1+, jinak buildy pro vyšší PHP padají kvůli závislosti, zrušit dev závislost před releasem 