### PR TITLE
Pridani verzovani

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.2.1",
+	"version": "3.3.0",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/DI/PdFormsExtension.php
+++ b/src/DI/PdFormsExtension.php
@@ -15,5 +15,8 @@ final class PdFormsExtension extends \Nette\DI\CompilerExtension
 		$builder->addDefinition($this->prefix('invisibleReCaptchaInputFactory'))
 			->setFactory(\Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInputFactory::class)
 		;
+
+		$builder->addDefinition($this->prefix('versioningProvider'))
+			->setFactory(\Pd\Forms\Versioning\DummyProvider::class);
 	}
 }

--- a/src/InvisibleReCaptcha/InvisibleReCaptchaInput.php
+++ b/src/InvisibleReCaptcha/InvisibleReCaptchaInput.php
@@ -14,11 +14,16 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	 */
 	private $form;
 
+	/**
+	 * @var \Pd\Forms\Versioning\Provider
+	 */
+	private $versioningProvider;
+
 
 	/**
 	 * @param \Contributte\ReCaptcha\ReCaptchaProvider $provider
 	 */
-	public function __construct(\Contributte\ReCaptcha\ReCaptchaProvider $provider, \Nette\Application\UI\Form $form, string $errorMessage)
+	public function __construct(\Contributte\ReCaptcha\ReCaptchaProvider $provider, \Nette\Application\UI\Form $form, string $errorMessage, \Pd\Forms\Versioning\Provider $versioningProvider)
 	{
 		parent::__construct($provider);
 		
@@ -27,6 +32,7 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 
 		$this->provider = $provider;
 		$this->form = $form;
+		$this->versioningProvider = $versioningProvider;
 	}
 
 	/**
@@ -65,7 +71,7 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	{
 		$script = \Nette\Utils\Html::el('script', [
 			'type' => 'text/javascript',
-			'src' => '/js/pdForms.recaptcha.min.js',
+			'src' => $this->versioningProvider->generatePathWithVersion('/js/pdForms.recaptcha.min.js'),
 		])->setHtml('');
 
 		return $script;

--- a/src/InvisibleReCaptcha/InvisibleReCaptchaInputFactory.php
+++ b/src/InvisibleReCaptcha/InvisibleReCaptchaInputFactory.php
@@ -9,18 +9,25 @@ class InvisibleReCaptchaInputFactory
 	 */
 	private $reCaptchaProvider;
 
+	/**
+	 * @var \Pd\Forms\Versioning\Provider
+	 */
+	private $versioningProvider;
+
 
 	public function __construct(
-		\Contributte\ReCaptcha\ReCaptchaProvider $reCaptchaProvider
+		\Contributte\ReCaptcha\ReCaptchaProvider $reCaptchaProvider,
+		\Pd\Forms\Versioning\Provider $versioningProvider
 
 	) {
 		$this->reCaptchaProvider = $reCaptchaProvider;
+		$this->versioningProvider = $versioningProvider;
 	}
 
 
 	public function create(\Nette\Application\UI\Form $form): \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput
 	{
-		return new \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput($this->reCaptchaProvider, $form, '_msg_spam_detected');
+		return new \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput($this->reCaptchaProvider, $form, '_msg_spam_detected', $this->versioningProvider);
 	}
 
 }

--- a/src/Versioning/DummyProvider.php
+++ b/src/Versioning/DummyProvider.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Forms\Versioning;
+
+class DummyProvider implements \Pd\Forms\Versioning\Provider
+{
+
+	public function generatePathWithVersion(string $filePath): string
+	{
+		return $filePath;
+	}
+}

--- a/src/Versioning/Provider.php
+++ b/src/Versioning/Provider.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Forms\Versioning;
+
+interface Provider
+{
+	public function generatePathWithVersion(string $filePath): string;
+}

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.2.1
+ * @version 3.3.0
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.2.1';
+	pdForms.version = '3.3.0';
 
 
 	/**


### PR DESCRIPTION
PR pdp: https://github.com/peckadesign/pdproject5/pull/2999
PR GWs: https://github.com/peckadesign/GlobalWines2018/pull/2407

Release:

Priani moznosti verzovat soubor s javascriptem (`'/js/pdForms.recaptcha.min.js'`). Toto verzovani zajistuje sluzba `versioningProvider`. Tato sluzba implementuje interface `\Pd\Forms\Versioning\Provider`. Ve vychozim stavu je pouzita trida `\Pd\Forms\Versioning\DummyProvider`, ktera pouze vraci to, co ji predame jako argument. 

Pokud tuto sluzbu chceme nahradit, je potreba v projektu tuto sluzbu prekryt timto zpusobem:
```
services:
	pdForms.versioningProvider:
		factory: \Pd\Bridge\PdVersionToPdForms\PdFormsVersionProvider
```

