### PR TITLE
Validace file inputů

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.4.3",
+	"version": "3.4.4",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.4.3
+ * @version 3.4.4
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.4.3';
+	pdForms.version = '3.4.4';
 
 
 	/**
@@ -683,9 +683,9 @@
 
 		addDelegatedEventListener(form, 'focusout change', 'select, textarea, input:not([type="submit"]):not([type="reset"])', setEverFocused);
 
-		addDelegatedEventListener(form, 'validate focusout',        'textarea, input:not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"])', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate focusout',        'textarea, input:not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]):not([type="file"])', pdForms.liveValidation);
 		addDelegatedEventListener(form, 'validate focusout change', 'select', pdForms.liveValidation);
-		addDelegatedEventListener(form, 'validate change',          'input[type="checkbox"], input[type="radio"]', pdForms.liveValidation);
+		addDelegatedEventListener(form, 'validate change',          'input[type="checkbox"], input[type="radio"], input[type="file"]', pdForms.liveValidation);
 
 		// Suggestions from custom messages
 		addDelegatedEventListener(form, 'click', '.pdforms-suggestion', pdForms.useSuggestion);


### PR DESCRIPTION
Při zobrazení dialogového okna pro výběr souboru dojde k vyvolání události `focusout`, která způsobí validaci a tudíž rovnou zobrazení chybové hlášky u povinných file inputů. Z tohoto důvodu je potřeba u file inputů odebrat validaci při `focusout` a nechat pouze `change`.

#45 