### PR TITLE
Přidání nonce attributu pro scripty do recaptcha inputu

### DIFF
--- a/src/ContentSecurityPolicy/ContentSecurityPolicyInterface.php
+++ b/src/ContentSecurityPolicy/ContentSecurityPolicyInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\Forms\ContentSecurityPolicy;
+
+interface ContentSecurityPolicyInterface
+{
+
+	public function getNonce(): ?string;
+
+}

--- a/src/InvisibleReCaptcha/InvisibleReCaptchaInput.php
+++ b/src/InvisibleReCaptcha/InvisibleReCaptchaInput.php
@@ -28,9 +28,6 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	}
 
 
-	/**
-	 * @return \Nette\Utils\Html<\Nette\Utils\Html|string>
-	 */
 	public function getControl(): \Nette\Utils\Html
 	{
 		$formHtmlId = \sprintf(\Nette\Forms\Controls\BaseControl::$idMask, $this->form->lookupPath()); //pozor: musi se volat az zde, protoze teprve az ted je formular pripojen do nejake komponenty a muzeme volat lookupPath().
@@ -58,9 +55,6 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	}
 
 
-	/**
-	 * @return \Nette\Utils\Html<\Nette\Utils\Html|string>
-	 */
 	private function getReCaptchaScript(): \Nette\Utils\Html
 	{
 		$script = \Nette\Utils\Html::el('script', [
@@ -72,9 +66,6 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	}
 
 
-	/**
-	 * @return \Nette\Utils\Html<\Nette\Utils\Html|string>
-	 */
 	private function getReCaptchaInitScript(string $formHtmlId): \Nette\Utils\Html
 	{
 		$script = \Nette\Utils\Html::el('script')->setHtml('if (typeof pdForms !== "undefined" && pdForms.recaptcha) { pdForms.recaptcha.initForm("' . $formHtmlId . '"); }');
@@ -83,9 +74,6 @@ class InvisibleReCaptchaInput extends \Contributte\ReCaptcha\Forms\ReCaptchaFiel
 	}
 
 
-	/**
-	 * @return \Nette\Utils\Html<\Nette\Utils\Html|string>
-	 */
 	private function getReCaptchaDiv(): \Nette\Utils\Html
 	{
 		$div = \Nette\Utils\Html::el('div');

--- a/src/InvisibleReCaptcha/InvisibleReCaptchaInputFactory.php
+++ b/src/InvisibleReCaptcha/InvisibleReCaptchaInputFactory.php
@@ -9,20 +9,24 @@ class InvisibleReCaptchaInputFactory
 
 	private \Pd\Forms\Versioning\Provider $versioningProvider;
 
+	private ?\Pd\Forms\ContentSecurityPolicy\ContentSecurityPolicyInterface $contentSecurityPolicy = NULL;
+
 
 	public function __construct(
 		\Contributte\ReCaptcha\ReCaptchaProvider $reCaptchaProvider,
-		\Pd\Forms\Versioning\Provider $versioningProvider
+		\Pd\Forms\Versioning\Provider $versioningProvider,
+		?\Pd\Forms\ContentSecurityPolicy\ContentSecurityPolicyInterface $contentSecurityPolicy = NULL
 
 	) {
 		$this->reCaptchaProvider = $reCaptchaProvider;
 		$this->versioningProvider = $versioningProvider;
+		$this->contentSecurityPolicy = $contentSecurityPolicy;
 	}
 
 
 	public function create(\Nette\Application\UI\Form $form): \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput
 	{
-		return new \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput($this->reCaptchaProvider, $form, '_msg_spam_detected', $this->versioningProvider);
+		return new \Pd\Forms\InvisibleReCaptcha\InvisibleReCaptchaInput($this->reCaptchaProvider, $form, '_msg_spam_detected', $this->versioningProvider, $this->contentSecurityPolicy);
 	}
 
 }


### PR DESCRIPTION
- nad inputem lze z formuláře setnout nonce, kterou lze získat z Nette skrz Response. Pokud nonce je NULL tak se ve scriptu neobjeví.
- slouží pro Content Security Policy