### PR TITLE
Oprava validací radio inputů

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 3.6.0
+ * @version 3.6.1
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '3.6.0';
+	pdForms.version = '3.6.1';
 
 
 	/**
@@ -142,7 +142,7 @@
 	 * This function is not used when validating whole form, eg. by submit event.
 	 */
 	pdForms.liveValidation = function(e) {
-		var validate = [e.target];
+		var validate = e.target.type === 'radio' ? Array.from(e.target.form[e.target.name]) : [e.target];
 		var groupName = e.target.getAttribute('data-pdforms-validation-group');
 
 		if (groupName) {
@@ -672,7 +672,18 @@
 	var setEverFocused = function(e) {
 		var everFocused = e.target.getAttribute('data-pdforms-ever-focused');
 
-		if (! everFocused) {
+		if (everFocused) {
+			return;
+		}
+
+		if (e.target.type === 'radio') {
+			var radioList = e.target.form[e.target.name];
+
+			for (var i = 0; i < radioList.length; i++) {
+				radioList.item(i).setAttribute('data-pdforms-ever-focused', true);
+			}
+
+		} else {
 			e.target.setAttribute('data-pdforms-ever-focused', true);
 		}
 	}


### PR DESCRIPTION
V případě validování radio inputů validuje vždy všechny radio s daným jménem. Díky tomu jsou vždy všechny radio buttony s daným jménem vždy ve stejném validačním stavu. Dále upravuje logiku nastavování interního `ever-focused` flagu, který určitě, zda se input validuje - v případě radio buttonů nastavuje všem se stejným jménem.