### PR TITLE
#1 Úprava scrollování po validování formuláře

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "4.0.1",
+	"version": "4.1.0",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 4.0.1
+ * @version 4.1.0
  *
  * Features:
  * - live validation

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -595,6 +595,31 @@
 
 
 	/**
+	 * Scroll into first error after validation.
+	 */
+	pdForms.afterValidationScroll = function (form, firstErrorElem) {
+		if (! firstErrorElem) {
+			form.scrollIntoView();
+			return;
+		}
+
+		var placeholder = pdForms.getMessagePlaceholder(firstErrorElem)
+
+		if (placeholder.isGlobal || firstErrorElem.type === 'hidden') {
+			(placeholder.elem ?? form).scrollIntoView()
+
+			firstErrorElem.focus({
+				preventScroll: true
+			});
+
+			return;
+		}
+
+		firstErrorElem.focus()
+	}
+
+
+	/**
 	 * Optional rules are defined using "optional" property in "arg". We have to convert arg into Nette format before
 	 * validating. This means removing all properties but data from arg and storing them elsewhere.
 	 */
@@ -644,8 +669,8 @@
 			}
 		}
 
-		if (focusElem) {
-			focusElem.focus();
+		if (errors.length) {
+			pdForms.afterValidationScroll(form, focusElem);
 		}
 	};
 


### PR DESCRIPTION
Souvisí s #1. Neumožňuje přímo nastavit, kam se scrolluje, ale vylepšuje automatické scrollování. Nastavit fixní místo pro zascrollování imho nedává smysl. Pokud by chyba byla, jak je popsáno v #1 na nějakém prvku, který zobrazuje chybu na začátku formuláře, ale první chyba byla na jiném prvku (s chybou vypsanou u něj), pak dává smysl zascrollovat např. nahoru i přes první prvek s chybou. Ale pokud by byla chyba jen na prvku, který vypisuje chybu u sebe, dává smysl zascrollovat na tento prvek. Jinými slovy, pokud je nějaký prvek s globálně umístěnou zprávou jiný, než první s chybou, tento PR toho moc nevyřeší. Pro takové případě je ale nyní nově možné přepsat novou metodu `afterValidationScroll(form, firstErrorElem)` nějakým vlastním způsobem. Nové chování by ale mělo většinu problémů řešit. Nové defaultní chování viz popis commitu:

- Po zvalidování nově scrollujeme podle složitější logiky. Pokud není žádný focusovatelný prvek na základě validace (ale validace má nějaké chyby), přesouváme na začátek formuláře. Pokud máme focusovatelný prvek (první chybný input formuláře), pak pokud není typu hidden a zároveň nemá nastaveno globální umístění zprávy, pak do něj přesouváme focus a prohlížeč zajistí scroll. V případě hidden prvků, nebo prvků s globální validační zprávou scrollujeme přímo na placeholder (nebo formulář).