### PR TITLE
Oprava opakované inicializace formuláře

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -712,6 +712,11 @@
 	 * Setup handlers.
 	 */
 	Nette.initForm = function (form) {
+		// Skip already initialized forms
+		if (form.noValidate) {
+			return;
+		}
+
 		pdForms.Nette.initForm(form);
 
 		addDelegatedEventListener(form, 'focusout change', 'select, textarea, input:not([type="submit"]):not([type="reset"])', setEverFocused);

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 4.1.0
+ * @version 4.1.1
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '4.0.1';
+	pdForms.version = '4.1.1';
 
 
 	/**


### PR DESCRIPTION
Pokud byl formulář již inicializován, zapisuje `Nette.initForm` na formulář `form.noValidate = true`. Pokud tedy narazíme na `form.noValidate`, neinicializujeme formulář, protože bychom navazovali jednotlivé callbacky opakovaně.