### PR TITLE
Oprava inicializace formulářů

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -712,16 +712,16 @@
 	/**
 	 * Setup handlers.
 	 */
-	Nette.initForm = function (form) {
+	Nette.initForm = function (form, event) {
 		// Skip already initialized forms
 		if (form.noValidate) {
 			// Always call the original `initForm` method. This method handles already initialised forms itself.
-			pdForms.Nette.initForm(form);
+			pdForms.Nette.initForm(form, event);
 
 			return;
 		}
 
-		pdForms.Nette.initForm(form);
+		pdForms.Nette.initForm(form, event);
 
 		addDelegatedEventListener(form, 'focusout change', 'select, textarea, input:not([type="submit"]):not([type="reset"])', setEverFocused);
 

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 4.1.1
+ * @version 4.1.2
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '4.1.1';
+	pdForms.version = '4.1.2';
 
 
 	/**
@@ -155,6 +155,7 @@
 				}
 			}
 		}
+
 
 		validate.forEach(function(elem) {
 			if (elem.getAttribute('data-pdforms-ever-focused')) {
@@ -714,6 +715,9 @@
 	Nette.initForm = function (form) {
 		// Skip already initialized forms
 		if (form.noValidate) {
+			// Always call the original `initForm` method. This method handles already initialised forms itself.
+			pdForms.Nette.initForm(form);
+
 			return;
 		}
 


### PR DESCRIPTION
Původní metodu `Nette.initForm` chceme volat vždy. Sama o sobě obsahuje kontrolu na opětovnou inicializaci, na začátku ale ještě spouští nastavení, které je nutné udělat i po ajaxu (jmenovitě inicializace toggle elementů). Metoda `Nette.toggleControl` je pak v Nette ošetřená proti vícenásobnému navázání handleru pomocí weakMap.