### PR TITLE
Oprava mazání chyb z `RadioNodeList`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "4.1.3",
+	"version": "4.1.4",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 4.1.3
+ * @version 4.1.4
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '4.1.3';
+	pdForms.version = '4.1.4';
 
 
 	/**

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -620,12 +620,12 @@
 	 * validating. This means removing all properties but data from arg and storing them elsewhere.
 	 */
 	Nette.validateControl = function(elem, rules, onlyCheck, value, emptyOptional) {
+		elem = elem.tagName ? elem : elem[0]; // RadioNodeList
+
 		// assumes the input is valid, therefore removing all messages except those associated with ajax rules; this
 		// prevents flashing of message, when ajax rule is evaluated - ajax rules removes their messages when the ajax
 		// rule is evaluated
 		pdForms.removeMessages(elem, false);
-
-		elem = elem.tagName ? elem : elem[0]; // RadioNodeList
 
 		if (! rules) {
 			rules = JSON.parse(elem.getAttribute('data-nette-rules') || '[]');


### PR DESCRIPTION
- Pokud byl element `RadioNodeList`, do `pdForms.removeMessages` se posílal chybně místo `Element` právě `RadioNodeList`, což mohlo způsobit chybu. Nyní je v metodě `validateControl` správně pořadí tak, že nejprve ošetříme `RadioNodeList` a teprve poté voláme `removeMessages`.