### PR TITLE
fix kompatibility s nette/forms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"nette/tester": "~2.3.2",
 		"mockery/mockery": "^1.0",
 		"pd/coding-standard": "1.27.*",
-		"phpstan/phpstan": "^1.4.0"
+		"phpstan/phpstan": "~1.4.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -22,7 +22,7 @@ final class Rules
 	/**
 	 * @param \Nette\Forms\Controls\BaseControl $control
 	 */
-	public static function ajax(\Nette\Forms\Control $control, \Pd\Forms\RuleOptions $options): bool
+	public static function ajax(\Nette\Forms\IControl $control, \Pd\Forms\RuleOptions $options): bool
 	{
 		if ($options->isOptional()) {
 			return TRUE;
@@ -54,13 +54,13 @@ final class Rules
 	/**
 	 * Rule is never validated on backend, used for proxying nette rules as optional only
 	 */
-	public static function netteRuleProxy(\Nette\Forms\Control $control, \Pd\Forms\RuleOptions $options): bool
+	public static function netteRuleProxy(\Nette\Forms\IControl $control, \Pd\Forms\RuleOptions $options): bool
 	{
 		return TRUE;
 	}
 
 
-	public static function phone(\Nette\Forms\Control $control, ?\Pd\Forms\RuleOptions $options): bool
+	public static function phone(\Nette\Forms\IControl $control, ?\Pd\Forms\RuleOptions $options): bool
 	{
 		if ($options !== NULL && $options->isOptional()) {
 			return TRUE;
@@ -70,7 +70,7 @@ final class Rules
 	}
 
 
-	public static function containsNumber(\Nette\Forms\Control $control, ?\Pd\Forms\RuleOptions $options): bool
+	public static function containsNumber(\Nette\Forms\IControl $control, ?\Pd\Forms\RuleOptions $options): bool
 	{
 		if ($options !== NULL && $options->isOptional()) {
 			return TRUE;
@@ -80,7 +80,7 @@ final class Rules
 	}
 
 
-	public static function noExternalSources(\Nette\Forms\Control $control, ?\Pd\Forms\RuleOptions $options): bool
+	public static function noExternalSources(\Nette\Forms\IControl $control, ?\Pd\Forms\RuleOptions $options): bool
 	{
 		if ($options !== NULL && ($options->isOptional() || ! $control->getValue())) {
 			return TRUE;
@@ -90,7 +90,7 @@ final class Rules
 	}
 
 
-	public static function czechCompanyIdentifier(\Nette\Forms\Control $control, ?\Pd\Forms\RuleOptions $options): bool
+	public static function czechCompanyIdentifier(\Nette\Forms\IControl $control, ?\Pd\Forms\RuleOptions $options): bool
 	{
 		if ($options !== NULL && $options->isOptional()) {
 			return TRUE;


### PR DESCRIPTION
 - v releasu 4.0.0 se změnilo IControl na Control, který je v nette/forms od verze 3.1
 - podpora v composer.json, ale zůstala i pro nette/forms 2.4
 - vzhledem k tomu, že IControl bylo z nette/forms odstraněno až ve verzi 4.0, tak vrátíme úpravu zpět, ať je zachována podpora nette/forms uvedená v composer.json