### PR TITLE
Oprava live validací

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd-forms",
 	"title": "pdForms",
 	"description": "Customization of netteForms for use in PeckaDesign.",
-	"version": "4.2.1",
+	"version": "4.2.2",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -1,7 +1,7 @@
 /**
  * @name pdForms
  * @author Radek Šerý <radek.sery@peckadesign.cz>
- * @version 4.2.1
+ * @version 4.2.2
  *
  * Features:
  * - live validation
@@ -45,7 +45,7 @@
 
 	var pdForms = window.pdForms || {};
 
-	pdForms.version = '4.2.1';
+	pdForms.version = '4.2.2';
 
 
 	/**

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -160,6 +160,11 @@
 
 		validate.forEach(function(elem) {
 			if (elem.getAttribute('data-pdforms-ever-focused')) {
+				// Assumes the input is valid, therefore removing all messages except those associated with ajax rules.
+				// This prevents flashing of messages when the ajax rule is evaluated - ajax rules remove their messages
+				// when the ajax rule is evaluated
+				pdForms.removeMessages(elem, false);
+
 				var rules = JSON.parse(elem.getAttribute('data-nette-rules') || '[]');
 				rules = pdForms.normalizeRules(rules);
 


### PR DESCRIPTION
Dokončení revertu z předchozího release. Při live validaci je potřeba mazat na začátku zprávy. Toto bylo původně přesunuto do `validateControl`, ale poté odebráno a přesunuto do `validateForm`. Nyní tedy vracíme ještě i do `liveValidation`, aby zprávy byly odebírány při každé opětovné validaci inputu.