### PR TITLE
Oprava vkládání zpráv při zanořených placeholderech

### DIFF
--- a/doc/live_validation.md
+++ b/doc/live_validation.md
@@ -28,7 +28,7 @@ Pokud chcete validovat formulářové pole při libovolné jiné události (`key
 V případě validační chyby se vypsání chyby řídí několika pravidly. V prvné řadě je možno určit, zda se má chyba vypsat přímo u formulářového prvku nebo "globálně" v určeném místě.
 
 #### Vypsání chyby přímo u formulářového prvku
-Toto chování je výchozí, element pro vložení chybové hlášky se hledá v DOM jako nejbližší rodič s class `pdforms-messages--input`, případně jako nejbližší tag `<p>`. Do tohoto prvku je pak vložena validační zpráva v následujícím formátu:
+Toto chování je výchozí, element pro vložení chybové hlášky se hledá v DOM jako nejbližší rodič s class `pdforms-messages--input` nebo jako nejbližší `<p>`, který má vlastní element zpráv `pdforms-messages__aria`. Pokud takový rodič neexistuje, použije se nejbližší tag `<p>`. Do tohoto prvku je pak vložena validační zpráva v následujícím formátu:
 ```html
 <label for="muj_input" data-elem="muj_input" class="inp-error pdforms-message">Text validační zprávy</label>
 ``` 
@@ -36,6 +36,8 @@ Toto chování je výchozí, element pro vložení chybové hlášky se hledá v
 Pokud nechceme použít pro validační chyby element `label`, lze pomocí data atributu `data-pdforms-messages-tagname` určit libovolný jiný tag, např. `data-pdforms-messages-tagname="span"`. Class u zprávy je ve tvaru `inp-(error|info|valid)`, případně `message message--(error|info|valid)` (pokud byl použit tag `<p>`).
 
 Zda se label prvek vloží na začátek nebo konec elementu můžeme ovlivnit uvedením `data-pdforms-messages-prepend="true"`, výchozí chování je vložení nakonec. Tento data atribut se neuvádí na formulářový prvek, ale prvek, do kterého se validační zpráva vkládá.
+
+Pokud nalezený element obsahuje vlastní element s class `pdforms-messages__aria` (typicky `aria-live` region), vkládají se zprávy do něj. Elementy zpráv patřící vnořeným formulářovým prvkům se přeskakují, tj. nepoužije se takový, mezi kterým a nalezeným elementem leží další `pdforms-messages--input` nebo `<p>`. Díky tomu je možné mít uvnitř elementu `pdforms-messages--input` (např. uvnitř `<fieldset>` s radiolistem) vnořené další formulářové prvky s vlastními zprávami.
 
 V případě, že se podle výše uvedeného postupu nenajde element pro vložení zprávy, zkouší se zpráva umístit do "globálního" elementu zpráv.
 

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -376,6 +376,30 @@
 
 
 	/**
+	 * Elements which may serve as a message placeholder of a single control. Plain `p` is not part of this selector
+	 * on purpose - it is used as a fallback only, so that a `p` without its own messages element (eg. an item of a
+	 * checkbox list) doesn't shadow the placeholder of the whole list.
+	 */
+	pdForms.placeholderSelector = '.pdforms-messages--input, p:has(> .pdforms-messages__aria)';
+
+	/**
+	 * Elements delimiting the placeholder of one control from a placeholder of a control nested inside it.
+	 */
+	pdForms.placeholderBoundarySelector = '.pdforms-messages--input, p';
+
+
+	/**
+	 * Find the element messages are inserted into. Only the placeholder's own messages element is used, elements
+	 * belonging to nested controls are skipped.
+	 */
+	pdForms.getMessagesTarget = function(placeholder) {
+		var selector = '.pdforms-messages__aria:not(:scope :is(' + pdForms.placeholderBoundarySelector + ') .pdforms-messages__aria)';
+
+		return placeholder.querySelector(selector) || placeholder;
+	};
+
+
+	/**
 	 * Find the placeholder element for a given input element.
 	 */
 	pdForms.getMessagePlaceholder = function(elem) {
@@ -387,7 +411,7 @@
 
 		} else {
 			placeholder =
-				elem.closest('.pdforms-messages--input') ||
+				elem.closest(pdForms.placeholderSelector) ||
 				elem.closest('p');
 
 			if (! placeholder) {
@@ -414,10 +438,12 @@
 	/**
 	 * Display message. Either input associated or (if appropriate selector not found) as "global" form message.
 	 * Message placeholding:
-	 * 	1. First we try to find elements parent .pdforms-messages--input
+	 * 	1. First we try to find closest elements parent matching pdForms.placeholderSelector, ie. either
+	 * 	   .pdforms-messages--input or a p having its own .pdforms-messages__aria
 	 * 	2. If there is not any, then try to find closest p
 	 * 	3. If still no success, try to find .pdforms-messages--global
-	 * 	4. If placeholder contains .pdforms-messages__aria, message will be inserted into it instead of placeholder element
+	 * 	4. If placeholder contains its own .pdforms-messages__aria, message will be inserted into it instead of
+	 * 	   placeholder element; messages elements of nested controls are skipped, see pdForms.getMessagesTarget
 	 *
 	 * If two or more inputs with validation rules are in same message placeholder (eg. <p> or .pdforms-messages--input), the
 	 * validation won't work as expected - class .error will be determined by last validated input in the placeholder and
@@ -473,7 +499,7 @@
 				msg.setAttribute(tagName === 'label' ? 'for' : 'data-for', elem.id);
 			}
 
-			placeholder.elem = placeholder.elem?.querySelector('.pdforms-messages__aria') || placeholder.elem
+			placeholder.elem = pdForms.getMessagesTarget(placeholder.elem)
 
 			placeholder.elem.getAttribute('data-pdforms-messages-prepend') ?
 				placeholder.elem.insertAdjacentElement('afterBegin', msg) :
@@ -496,7 +522,7 @@
 
 		// Find placeholders for input (input and global)
 		var placeholder =
-			elem.closest('.pdforms-messages--input') ||
+			elem.closest(pdForms.placeholderSelector) ||
 			elem.closest('p');
 
 		var globalPlaceholder = elem.form.querySelector('.pdforms-messages--global');


### PR DESCRIPTION
## Problém

Mechanika hledání elementu pro validační zprávy nepočítala se zanořováním, tj. se situací, kdy uvnitř placeholderu jedné kontrolky (typicky `<fieldset>` radiolistu s class `pdforms-messages--input`) leží další formulářové prvky s vlastními zprávami.

Konkrétně na dvou místech:

1. `getMessagePlaceholder()` hledala `elem.closest('.pdforms-messages--input')` s absolutní přednostní před `<p>`, bez ohledu na vzdálenost. Vnořený input má vlastní `<p>` z `~input`, ale ten se přeskočil a vyhrál až fieldset nadřazeného radiolistu, takže zprávy vnořených inputů skončily u nadřazené kontrolky (a `pdforms-error` class na jejím wrapperu).
2. `addMessage()` hledala cílový element jako `placeholder.querySelector('.pdforms-messages__aria')`, což prohledává celý podstrom v document order. Fieldset radiolistu má vlastní element zpráv až za výpisem položek, takže první nalezený byl ten z vnořeného formuláře - chyba radiolistu se vypsala u prvního vnořeného inputu.

Tytéž selektory duplicitně používala i `removeMessages()`, takže se `pdforms-error` odebíralo ze špatného elementu.

## Řešení

Dva selektory jako veřejné vlastnosti `pdForms` (lze je tedy v projektu přebít) a nový `pdForms.getMessagesTarget()`:

```js
pdForms.placeholderSelector = '.pdforms-messages--input, p:has(> .pdforms-messages__aria)';
pdForms.placeholderBoundarySelector = '.pdforms-messages--input, p';
```

- **Placeholder:** `closest(pdForms.placeholderSelector) || closest('p')`. Placeholderem je nově i `<p>`, které má vlastní element zpráv - vnořený input tak najde sám sebe, aniž by bylo nutné mu dopisovat `pdforms-messages--input`. Samotné `p` zůstává jen jako fallback, protože `closest()` řeší prioritu podle blízkosti v DOM, ne podle pořadí v selektoru; při jednom společném selektoru by u běžného radiolistu vyhrála položka `p.form-bool` (bez vlastního elementu zpráv) nad fieldsetem celého listu.
- **Cílový element:** vkládá se výhradně do vlastního elementu zpráv nalezeného placeholderu. Vyloučení řeší `:not(:scope :is(<boundary>) .pdforms-messages__aria)`, tedy nikoli vazba na přímého potomka - element zpráv může být zanořený hlouběji, vyloučí se jen ten, mezi kterým a placeholderem leží další placeholder.

## Ověření

Změna byla ověřena na projektu model-obaly (checkout, uložené adresy s vnořeným formulářem jiné adresy) a proti syntetickému DOM se všemi tvary, které se v projektech vyskytují:

| input | před | po |
|---|---|---|
| radio v listu | fieldset -> element zpráv vnořeného inputu | fieldset -> vlastní element zpráv |
| vnořený input bez `--input` | fieldset -> element zpráv vnořeného inputu | vlastní `p` -> vlastní element zpráv |
| vnořený input s `--input` | vlastní `p` | bez změny |
| `--input` wrapper, element zpráv zanořený v divu | wrapper | bez změny |
| list vnořený v listu | vnořený fieldset | bez změny |
| solo checkbox / `p` bez elementu zpráv | vlastní `p` | bez změny |

Mění se tedy jen ty dva vadné případy.

`:has()` a `:not()` s komplexním selektorem jsou Baseline, `browserslist: defaults` je pokrývá.

## Dokumentace

Aktualizovaný doc komentář nad `addMessage()` a sekce „Vypsání chyby přímo u formulářového prvku" v `doc/live_validation.md` - popisovala staré pravidlo výběru a element zpráv `pdforms-messages__aria` (přidaný v #66) v dokumentaci nebyl vůbec.
