### PR TITLE
Sjednocení selektoru placeholderu a hranice zanoření

### DIFF
--- a/doc/live_validation.md
+++ b/doc/live_validation.md
@@ -28,7 +28,7 @@ Pokud chcete validovat formulářové pole při libovolné jiné události (`key
 V případě validační chyby se vypsání chyby řídí několika pravidly. V prvné řadě je možno určit, zda se má chyba vypsat přímo u formulářového prvku nebo "globálně" v určeném místě.
 
 #### Vypsání chyby přímo u formulářového prvku
-Toto chování je výchozí, element pro vložení chybové hlášky se hledá v DOM jako nejbližší rodič s class `pdforms-messages--input` nebo jako nejbližší `<p>`, který má vlastní element zpráv `pdforms-messages__aria`. Pokud takový rodič neexistuje, použije se nejbližší tag `<p>`. Do tohoto prvku je pak vložena validační zpráva v následujícím formátu:
+Toto chování je výchozí, element pro vložení chybové hlášky se hledá v DOM jako nejbližší rodič s class `pdforms-messages--input` nebo jako nejbližší rodič, který má vlastní element zpráv `pdforms-messages__aria`. Pokud takový rodič neexistuje, použije se nejbližší tag `<p>`. Do tohoto prvku je pak vložena validační zpráva v následujícím formátu:
 ```html
 <label for="muj_input" data-elem="muj_input" class="inp-error pdforms-message">Text validační zprávy</label>
 ``` 
@@ -37,7 +37,7 @@ Pokud nechceme použít pro validační chyby element `label`, lze pomocí data 
 
 Zda se label prvek vloží na začátek nebo konec elementu můžeme ovlivnit uvedením `data-pdforms-messages-prepend="true"`, výchozí chování je vložení nakonec. Tento data atribut se neuvádí na formulářový prvek, ale prvek, do kterého se validační zpráva vkládá.
 
-Pokud nalezený element obsahuje vlastní element s class `pdforms-messages__aria` (typicky `aria-live` region), vkládají se zprávy do něj. Elementy zpráv patřící vnořeným formulářovým prvkům se přeskakují, tj. nepoužije se takový, mezi kterým a nalezeným elementem leží další `pdforms-messages--input` nebo `<p>`. Díky tomu je možné mít uvnitř elementu `pdforms-messages--input` (např. uvnitř `<fieldset>` s radiolistem) vnořené další formulářové prvky s vlastními zprávami.
+Pokud nalezený element obsahuje vlastní element s class `pdforms-messages__aria` (typicky `aria-live` region), vkládají se zprávy do něj. Elementy zpráv patřící vnořeným formulářovým prvkům se přeskakují, tj. nepoužije se takový, mezi kterým a nalezeným elementem leží element, který sám může být placeholderem (`pdforms-messages--input`, element s vlastním elementem zpráv, nebo `<p>`). Díky tomu je možné mít uvnitř elementu `pdforms-messages--input` (např. uvnitř `<fieldset>` s radiolistem) vnořené další formulářové prvky s vlastními zprávami.
 
 V případě, že se podle výše uvedeného postupu nenajde element pro vložení zprávy, zkouší se zpráva umístit do "globálního" elementu zpráv.
 

--- a/src/assets/pdForms.js
+++ b/src/assets/pdForms.js
@@ -380,20 +380,16 @@
 	 * on purpose - it is used as a fallback only, so that a `p` without its own messages element (eg. an item of a
 	 * checkbox list) doesn't shadow the placeholder of the whole list.
 	 */
-	pdForms.placeholderSelector = '.pdforms-messages--input, p:has(> .pdforms-messages__aria)';
-
-	/**
-	 * Elements delimiting the placeholder of one control from a placeholder of a control nested inside it.
-	 */
-	pdForms.placeholderBoundarySelector = '.pdforms-messages--input, p';
+	pdForms.placeholderSelector = '.pdforms-messages--input, :has(> .pdforms-messages__aria)';
 
 
 	/**
 	 * Find the element messages are inserted into. Only the placeholder's own messages element is used, elements
-	 * belonging to nested controls are skipped.
+	 * belonging to nested controls are skipped. Nesting is delimited by everything which may become a placeholder
+	 * of another control, ie. by pdForms.placeholderSelector plus the `p` fallback from getMessagePlaceholder.
 	 */
 	pdForms.getMessagesTarget = function(placeholder) {
-		var selector = '.pdforms-messages__aria:not(:scope :is(' + pdForms.placeholderBoundarySelector + ') .pdforms-messages__aria)';
+		var selector = '.pdforms-messages__aria:not(:scope :is(' + pdForms.placeholderSelector + ', p) .pdforms-messages__aria)';
 
 		return placeholder.querySelector(selector) || placeholder;
 	};
@@ -439,7 +435,7 @@
 	 * Display message. Either input associated or (if appropriate selector not found) as "global" form message.
 	 * Message placeholding:
 	 * 	1. First we try to find closest elements parent matching pdForms.placeholderSelector, ie. either
-	 * 	   .pdforms-messages--input or a p having its own .pdforms-messages__aria
+	 * 	   .pdforms-messages--input or an element having its own .pdforms-messages__aria
 	 * 	2. If there is not any, then try to find closest p
 	 * 	3. If still no success, try to find .pdforms-messages--global
 	 * 	4. If placeholder contains its own .pdforms-messages__aria, message will be inserted into it instead of


### PR DESCRIPTION
Navazuje na #71.

## Problém

V #71 je placeholder hledán selektorem `.pdforms-messages--input, p:has(> .pdforms-messages__aria)`, ale hranice zanoření (vylučování cizích elementů zpráv v `getMessagesTarget()`) je `.pdforms-messages--input, p`. Tyto dvě množiny se rozcházejí: element, který má vlastní element zpráv, ale není `<p>` (typicky `<div>` z komponenty vnořeného formuláře), **nemůže být placeholderem, ale není ani hranicí**. Jeho element zpráv se proto při hledání cíle nadřazené kontrolky nevyloučí a zpráva nadřazené kontrolky skončí u vnořené, tj. původní chyba v takové struktuře přežívá.

Naměřeno na struktuře `fieldset.pdforms-messages--input` (radiolist) obsahující vnořenou kontrolku obalenou `<div>` s vlastním elementem zpráv:

| stav | placeholder radiolistu | cílový element zpráv |
|---|---|---|
| 4.3.2 | `fieldset` | element zpráv vnořené kontrolky |
| #71 | `fieldset` | element zpráv vnořené kontrolky |
| tento PR | `fieldset` | vlastní element zpráv fieldsetu |

## Řešení

Placeholderem může být jakýkoli element s vlastním elementem zpráv (`:has(> .pdforms-messages__aria)`), ne jen `<p>`, a hranice zanoření se odvozuje přímo z `pdForms.placeholderSelector` plus `p` fallback, který používá `getMessagePlaceholder()`:

```js
pdForms.placeholderSelector = '.pdforms-messages--input, :has(> .pdforms-messages__aria)';

pdForms.getMessagesTarget = function(placeholder) {
	var selector = '.pdforms-messages__aria:not(:scope :is(' + pdForms.placeholderSelector + ', p) .pdforms-messages__aria)';

	return placeholder.querySelector(selector) || placeholder;
};
```

Invariant „množina placeholderů je podmnožinou hranic" je tak vynucený konstrukcí a projeví se i při přebití `placeholderSelector` v projektu. Vlastnost `pdForms.placeholderBoundarySelector` se proto ruší.

## Dopad

Jediná změna proti #71 mimo opravovaný tvar: pokud `--input` wrapper obsahuje neutrální element, který obaluje element zpráv (tj. element zpráv není přímým potomkem wrapperu), stane se placeholderem ten vnitřní element, takže na něj sednou stavové CSS třídy. Zpráva se v obou variantách vkládá do stejného elementu zpráv.

Ostatní tvary (radiolisty, vnořené listy, `--input` wrappery, samostatné `<p>`, `<p>` bez elementu zpráv) se chovají shodně jako ve 4.3.2.
